### PR TITLE
Updated landing page header with drop shadow

### DIFF
--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -4,10 +4,16 @@
   background-position: center;
   background-size: cover;
   background-repeat: no-repeat;
+
+  
+  .header-front-page {
+    background-image: linear-gradient(180deg, #000000 0%, rgba(51, 51, 51, 0.5) 50%), url(/images/splash.jpg)!important;
+  }
+
   @media screen {
     background-attachment: fixed;
   }
-
+  
   // Safari on iOS does not support fixed backgrounds
   // https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-touch-callout
   @supports (-webkit-touch-callout: none) {


### PR DESCRIPTION
This adds the backdrop shadow as discussed in #86. 

Please review @danyeaw.

Ah, one more thing, the dev environment looks like to cause some problem with me:
- I needed to install ruby-devel (I use Fedora)
- I also required to use `sudo` with `bundle install`
- And was required to add `webrick`: `bundle add webrick`

This updates `Gemfile` (which is not included in this PR) and adds `.ruby-version` (which is not added to `.gitignore`, do we need to add that?). Even though I setup using `rbenv`, my `ruby -v` command said:

```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
```

Anyways, This PR works, the above issue is secondary.

