### PR TITLE
Cleanup translation strings

### DIFF
--- a/_includes/content.md
+++ b/_includes/content.md
@@ -1,9 +1,12 @@
 {% capture thousand-words %}
+
 A picture is worth a thousand words. Describe and document your applications and
 systems with Gaphor to enhance knowledge sharing.
+
 {% endcapture %}
 
 {% capture about-content %}
+
 Gaphor is a UML, SysML, RAAML, and C4 modeling application. It is designed
 to be easy to use, while still being powerful. Gaphor implements a
 fully-compliant UML 2 data model, so it is much more than a picture
@@ -13,76 +16,108 @@ of a system as well as create complete, highly complex models.
 {% endcapture %}
 
 {% capture build %}
+
 Build Class, Interaction, and State Machine diagrams for software
 or Block Definition and Requirements diagrams for systems. Model
 the elements you need. If you want to mix and match, you can even
 add different diagram items to the same diagram to get the view you
 need.
+
 {% endcapture %}
 
 {% capture styling-engine %}
+
 Customize the diagrams you create with our built-in styling engine.
+
 {% endcapture %}
 
 {% capture treeview %}
+
 Easily find all element of your model in the tree view.
+
 {% endcapture %}
 
 {% capture dark-mode %}
+
 Love dark mode? We can do that too.
+
 {% endcapture %}
 
 {% capture download-content %}
+
 There are many ways to install Gaphor.
 The simplest is to download the official installer for Windows or macOS.
 For Linux you can install Gaphor using FlatHub.
-You can also use Python's built-in `pip` tool as long as you have all of the
+You can also use Python's built-in `pip` tool as long as you have all the
 required dependencies installed.
+
 {% endcapture %}
 
 {% capture blog-content %}
+
 Do you want to know what's going on with Gaphor? Read our blog!
 
 [Contact the team]({% link discuss.md %})
 if you want to share content related to Gaphor.
+
 {% endcapture %}
 
 {% capture see-blog %}
+
 See blog
+
 {% endcapture %}
 
 {% capture read-more %}
+
 Read more 
+
 {% endcapture %}
 
 {% capture download %}
+
 Download
+
 {% endcapture %}
 
 {% capture learn %}
+
 Learn more
+
 {% endcapture %}
 
 {% capture about %}
+
 About
+
 {% endcapture %}
 
 {% capture download %}
+
 Download
+
 {% endcapture %}
 
 {% capture tutorials %}
+
 Tutorials
+
 {% endcapture %}
 
 {% capture blog %}
+
 Blog
+
 {% endcapture %}
 
 {% capture discuss %}
+
 Get in touch
+
 {% endcapture %}
 
 {% capture contribute %}
+
 Contribute
+
 {% endcapture %}

--- a/_includes/footer.md
+++ b/_includes/footer.md
@@ -1,19 +1,29 @@
 {% capture love %}
+
 We love to hear from you
+
 {% endcapture %}
 
 {% capture open-issue %}
+
 Open an issue on GitHub
+
 {% endcapture %}
 
 {% capture tech-docs %}
- Tech docs
+
+Tech docs
+
 {% endcapture %}
 
 {% capture copyright %}
-Copyright &copy; 2020-2022 Arjan Molenaar and Dan Yeaw.
+
+Copyright &copy; 2020-2023 Arjan Molenaar and Dan Yeaw.
+
 {% endcapture %}
 
 {% capture theme %}
+
 Theme
+
 {% endcapture %}

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -20,7 +20,7 @@ layout: bare
                             <p>{{ thousand-words }}</p>
                         </div>
                         <a href="{% link index.md %}#about" title="{{ learn }}" class="btn header-button-one">{{ learn }}</a>
-                        <a href="{% link download.md %}" title="{{ download }}" class="btn header-button-two">{{ download }}</a>
+                        <a href="download" title="{{ download }}" class="btn header-button-two">{{ download }}</a>
                     </div>
                 </div>
             </div>

--- a/_platforms/03-linux.md
+++ b/_platforms/03-linux.md
@@ -6,8 +6,9 @@ language: en
 
 ### Flatpak
 
-[Flatpak](https://flatpak.org/) is the recommended way to install Gaphor in Linux. If you don't have it
-setup already, follow the instructions to [install Flatpak](https://flatpak.org/setup).
+[Flatpak](https://flatpak.org/) is the recommended way to install Gaphor in
+Linux. If you don't have it setup already, follow the instructions to [install
+Flatpak](https://flatpak.org/setup).
 
 <a href='https://flathub.org/apps/details/org.gaphor.Gaphor'><img width='240' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a>
 
@@ -22,8 +23,8 @@ flatpak install --user flathub org.gaphor.Gaphor
 ### AppImage
 
 The other option if you are running a recent Linux distribution is to use the
-[AppImage](https://appimage.org/). It is built using Ubuntu 18.04 and most likely
-won't work on older versions.
+[AppImage](https://appimage.org/). It is built using Ubuntu 18.04 and most
+likely won't work on older versions.
 
 <a class="btn btn-primary btn-lg" href="https://github.com/gaphor/gaphor/releases/download/{{ site.gaphor_version }}/Gaphor-{{ site.gaphor_version }}-x86_64.AppImage"><i class="fa fa-download"></i> Download AppImage</a>
 
@@ -32,7 +33,8 @@ chmod +x Gaphor-{{ site.gaphor_version }}-x86_64.AppImage
 ./Gaphor-{{ site.gaphor_version }}-x86_64.AppImage
 ```
 
-If you're using Wayland and the AppImage crashes, you can force it to use the X11 backend instead.
+If you're using Wayland and the AppImage crashes, you can force it to use the
+X11 backend instead.
 
 ```bash
 GDK_BACKEND=x11 ./Gaphor-{{ site.gaphor_version }}-x86_64.AppImage
@@ -40,4 +42,5 @@ GDK_BACKEND=x11 ./Gaphor-{{ site.gaphor_version }}-x86_64.AppImage
 
 ### Arch Linux
 
-Gaphor can be installed from an [AUR package](https://aur.archlinux.org/packages/python-gaphor/).
+Gaphor can be installed from an [AUR
+package](https://aur.archlinux.org/packages/python-gaphor/).

--- a/_platforms/04-python.md
+++ b/_platforms/04-python.md
@@ -5,13 +5,14 @@ language: en
 ---
 
 If you have the latest stable version of Python installed and the Gaphor
-dependencies installed, you can also install Gaphor using a wheel from [PyPI](https://pypi.org/project/gaphor/).
+dependencies installed, you can also install Gaphor using a wheel from
+[PyPI](https://pypi.org/project/gaphor/).
 
-If you don't have the latest stable version of Python and the Gaphor dependencies
-installed, follow the development environment [installation instructions](https://gaphor.readthedocs.io/en/latest/)
-section, but do not clone the repository.
-Optionally, create a
-[virtual environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments).
+If you don't have the latest stable version of Python and the Gaphor
+dependencies installed, follow the development environment [installation
+instructions](https://gaphor.readthedocs.io/en/latest/) section, but do not
+clone the repository. Optionally, create a [virtual
+environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments).
 Then execute the following:
 
 ```bash

--- a/contribute.md
+++ b/contribute.md
@@ -12,12 +12,11 @@ plenty of ways to contribute to Gaphor, no matter your level of experience or
 skill set.
 
 Our [technical documentation](https://gaphor.readthedocs.io) is hosted on the
-wonderful service that is [Read the Docs](https://readthedocs.com/).
-Not only does it contain details
-needed in order to make code contributions to Gaphor, but it outlines plenty of
-other ways in which you can contribute (including making updates to this
-website). Finally, it provides a guide to our processes and expectations for the
-various types of contribution you can make to Gaphor.
+wonderful service that is [Read the Docs](https://readthedocs.com/). Not only
+does it contain details needed in order to make code contributions to Gaphor,
+but it outlines plenty of other ways in which you can contribute (including
+making updates to this website). Finally, it provides a guide to our processes
+and expectations for the various types of contribution you can make to Gaphor.
 
 The source code is hosted on [GitHub](https://github.com/gaphor/gaphor).
 

--- a/cs/_includes/content.md
+++ b/cs/_includes/content.md
@@ -1,59 +1,123 @@
-{% capture thousand-words %} A picture is worth a thousand words. Describe
-and document your applications and systems with Gaphor to enhance knowledge
-sharing.  {% endcapture %}
+{% capture thousand-words %}
 
-{% capture about-content %} Gaphor is a UML, SysML, RAAML, and C4 modeling
-application. It is designed to be easy to use, while still being
-powerful. Gaphor implements a fully-compliant UML 2 data model, so it is
-much more than a picture drawing tool. You can use Gaphor to quickly
-visualize different aspects of a system as well as create complete, highly
-complex models.
+Obrázek vydá za tisíc slov. Popište a zdokumentujte své aplikace a systémy
+pomocí nástroje Gaphor, abyste zlepšili sdílení znalostí.
 
 {% endcapture %}
 
-{% capture build %} Build Class, Interaction, and State Machine diagrams for
-software or Block Definition and Requirements diagrams for systems. Model
-the elements you need. If you want to mix and match, you can even add
-different diagram items to the same diagram to get the view you need.  {%
-endcapture %}
+{% capture about-content %}
 
-{% capture styling-engine %} Customize the diagrams you create with our
-built-in styling engine.  {% endcapture %}
+Gaphor je aplikace pro modelování v jazycích UML, SysML, RAAML a C4. Je
+navržen tak, aby se snadno používal a zároveň byl výkonný. Gaphor
+implementuje plně kompatibilní datový model UML 2, takže je mnohem víc než
+jen nástrojem pro kreslení obrázků. Pomocí aplikace Gaphor můžete rychle
+vizualizovat různé aspekty systému i vytvářet kompletní, velmi složité
+modely.
 
-{% capture treeview %} Easily find all element of your model in the tree
-view.  {% endcapture %}
+{% endcapture %}
 
-{% capture dark-mode %} Love dark mode? We can do that too.  {% endcapture
-%}
+{% capture build %}
 
-{% capture download-content %} There are many ways to install Gaphor.  The
-simplest is to download the official installer for Windows or macOS.  For
-Linux you can install Gaphor using FlatHub.  You can also use Python's
-built-in `pip` tool as long as you have all of the required dependencies
-installed.  {% endcapture %}
+Sestavte diagramy tříd, interakcí a stavových strojů pro software nebo
+diagramy definic bloků a požadavků pro systémy. Modelujte prvky, které
+potřebujete. Chcete-li je kombinovat, můžete dokonce přidávat různé prvky
+diagramu do stejného diagramu, abyste získali potřebný pohled.
 
-{% capture blog-content %} Do you want to know what's going on with Gaphor?
-Read our blog!
+{% endcapture %}
+
+{% capture styling-engine %}
+
+Vytvořené diagramy si můžete přizpůsobit pomocí integrovaného stylovacího
+nástroje.
+
+{% endcapture %}
+
+{% capture treeview %}
+
+Snadné vyhledání všech prvků modelu ve stromovém zobrazení.
+
+{% endcapture %}
+
+{% capture dark-mode %}
+
+Milujete tmavý režim? I ten umíme.
+
+{% endcapture %}
+
+{% capture download-content %}
+
+Existuje mnoho způsobů instalace systému Gaphor. Nejjednodušší je stáhnout
+si oficiální instalační program pro Windows nebo macOS. Pro Linux můžete
+Gaphor nainstalovat pomocí FlatHubu.  Můžete také použít vestavěný nástroj
+`pip` pro Python, pokud máte nainstalovány všechny potřebné závislosti.
+
+{% endcapture %}
+
+{% capture blog-content %}
+
+Chcete vědět, co se děje s Gaphorem? Přečtěte si náš blog!
 
 [Contact the team]({% link discuss.md %})  if you want to share content
-related to Gaphor.  {% endcapture %}
+related to Gaphor.
 
-{% capture see-blog %} See blog {% endcapture %}
+{% endcapture %}
 
-{% capture read-more %} Read more {% endcapture %}
+{% capture see-blog %}
 
-{% capture download %} Download {% endcapture %}
+Zobrazit blog
 
-{% capture learn %} Learn more {% endcapture %}
+{% endcapture %}
 
-{% capture about %} About {% endcapture %}
+{% capture read-more %}
 
-{% capture download %} Download {% endcapture %}
+Přečtěte si více
 
-{% capture tutorials %} Tutorials {% endcapture %}
+{% endcapture %}
 
-{% capture blog %} Blog {% endcapture %}
+{% capture download %}
 
-{% capture discuss %} Get in touch {% endcapture %}
+Stáhnout
 
-{% capture contribute %} Contribute {% endcapture %}
+{% endcapture %}
+
+{% capture learn %}
+
+Zjistěte více
+
+{% endcapture %}
+
+{% capture about %}
+
+O nás
+
+{% endcapture %}
+
+{% capture download %}
+
+Stáhnout
+
+{% endcapture %}
+
+{% capture tutorials %}
+
+Tutoriály
+
+{% endcapture %}
+
+{% capture blog %}
+
+Blog
+
+{% endcapture %}
+
+{% capture discuss %}
+
+Spojte se s námi
+
+{% endcapture %}
+
+{% capture contribute %}
+
+Přispět
+
+{% endcapture %}

--- a/cs/_includes/footer.md
+++ b/cs/_includes/footer.md
@@ -1,12 +1,29 @@
-{% capture love %} We love to hear from you {% endcapture %}
+{% capture love %}
 
-{% capture open-issue %} Open an issue on GitHub {% endcapture %}
+Rádi vás uslyšíme
 
-{% capture tech-docs %}
- Tech docs
 {% endcapture %}
 
-{% capture copyright %} Copyright &copy; 2020-2022 Arjan Molenaar and Dan
-Yeaw.  {% endcapture %}
+{% capture open-issue %}
 
-{% capture theme %} Theme {% endcapture %}
+Otevřete problém na GitHubu
+
+{% endcapture %}
+
+{% capture tech-docs %}
+
+Technické dokumenty
+
+{% endcapture %}
+
+{% capture copyright %}
+
+Copyright &copy; 2020-2022 Arjan Molenaar a Dan Yeaw.
+
+{% endcapture %}
+
+{% capture theme %}
+
+Téma
+
+{% endcapture %}

--- a/cs/_platforms/04-python.md
+++ b/cs/_platforms/04-python.md
@@ -10,8 +10,8 @@ dependencies installed, you can also install Gaphor using a wheel from
 
 If you don't have the latest stable version of Python and the Gaphor
 dependencies installed, follow the development environment [installation
-instructions](https://gaphor.readthedocs.io/en/latest/)  section, but do not
-clone the repository.  Optionally, create a [virtual
+instructions](https://gaphor.readthedocs.io/en/latest/) section, but do not
+clone the repository. Optionally, create a [virtual
 environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments).
 Then execute the following:
 

--- a/cs/contribute.md
+++ b/cs/contribute.md
@@ -12,9 +12,9 @@ jak přispět ke Gaphoru, bez ohledu na úroveň vašich zkušeností nebo
 dovedností.
 
 Our [technical documentation](https://gaphor.readthedocs.io) is hosted on
-the wonderful service that is [Read the Docs](https://readthedocs.com/).
-Not only does it contain details needed in order to make code contributions
-to Gaphor, but it outlines plenty of other ways in which you can contribute
+the wonderful service that is [Read the Docs](https://readthedocs.com/). Not
+only does it contain details needed in order to make code contributions to
+Gaphor, but it outlines plenty of other ways in which you can contribute
 (including making updates to this website). Finally, it provides a guide to
 our processes and expectations for the various types of contribution you can
 make to Gaphor.

--- a/cs/tutorials.md
+++ b/cs/tutorials.md
@@ -21,10 +21,11 @@ Michigan Python meetup.
 ## Pokročilá témata
 
 - [Extend your models with
-stereotypes](https://gaphor.readthedocs.io/en/latest/stereotypes.html)  -
-[Writing a plugin]({% link tutorials/plugins.md %})  - [Technical and
-architectural documentation](https://gaphor.readthedocs.io/)  for
-contributors and plugin developers
+  stereotypes](https://gaphor.readthedocs.io/en/latest/stereotypes.html)
+- [Writing a plugin]({% link tutorials/plugins.md %})
+- [Technical and architectural
+documentation](https://gaphor.readthedocs.io/)  for contributors and plugin
+developers
 
 ## Rozhovory
 
@@ -45,8 +46,8 @@ There are some 10+ year old articles on Gaphor on the web. Some more recent
 articles are:
 
 - [Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on
-a Window 10.](https://www.methodsandtools.com/tools/gaphor.php)  - [It's
-FOSS has a short write-up on Gaphor
-(~2.8-ish?).](https://itsfoss.com/gaphor-modeling-tool/)  - [Ubuntu Pit has
-a nice article on Gaphor
-(~2.8-ish?).](https://www.ubuntupit.com/gaphor-an-open-source-simple-graphical-modeling-tool/)
+  a Window 10.](https://www.methodsandtools.com/tools/gaphor.php)
+- [It's FOSS has a short write-up on Gaphor
+  (~2.8-ish?).](https://itsfoss.com/gaphor-modeling-tool/)
+- [Ubuntu Pit has a nice article on Gaphor
+  (~2.8-ish?).](https://www.ubuntupit.com/gaphor-an-open-source-simple-graphical-modeling-tool/)

--- a/cs/tutorials/plugins.md
+++ b/cs/tutorials/plugins.md
@@ -5,6 +5,7 @@ layout: article
 redirect_from: /pages/writing-a-plugin.html
 title: 'Psaní zásuvného modulu'
 ---
+
 Gaphor je navržen tak, aby byl rozšiřitelný pomocí zásuvných modulů, které
 vám umožní rozšířit jeho funkce.
 

--- a/discuss.md
+++ b/discuss.md
@@ -9,9 +9,9 @@ handle: /discuss
 It's good to talk, share knowledge and learn from other users of Gaphor. Perhaps
 you have a question, problem or are unsure how to do something with Gaphor?
 Discussing such things in a supportive environment is a good way to make
-progress, make friends, and help. Put simply, Gaphor is a
-community focused project, and we have created a couple of online spaces where
-the community can come together.
+progress, make friends, and help. Put simply, Gaphor is a community focused
+project, and we have created a couple of online spaces where the community can
+come together.
 
 Contributions are welcome without prejudice from anyone irrespective of age,
 gender, religion, race, or sexuality. If you’re thinking, "but they don't mean

--- a/download.md
+++ b/download.md
@@ -13,7 +13,7 @@ handle: /download
 
 There are many ways to install Gaphor. The simplest is to download the official
 installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.
-You can also use Python's built-in `pip` tool as long as you have all of the
+You can also use Python's built-in `pip` tool as long as you have all the
 required dependencies installed.
 
 If you're a developer, you can find the source code [on

--- a/es/_includes/content.md
+++ b/es/_includes/content.md
@@ -1,59 +1,123 @@
-{% capture thousand-words %} A picture is worth a thousand words. Describe
-and document your applications and systems with Gaphor to enhance knowledge
-sharing.  {% endcapture %}
+{% capture thousand-words %}
 
-{% capture about-content %} Gaphor is a UML, SysML, RAAML, and C4 modeling
-application. It is designed to be easy to use, while still being
-powerful. Gaphor implements a fully-compliant UML 2 data model, so it is
-much more than a picture drawing tool. You can use Gaphor to quickly
-visualize different aspects of a system as well as create complete, highly
-complex models.
+Una imagen vale más que mil palabras. Describa y documente sus aplicaciones
+y sistemas con Gaphor para mejorar el intercambio de conocimientos.
 
 {% endcapture %}
 
-{% capture build %} Build Class, Interaction, and State Machine diagrams for
-software or Block Definition and Requirements diagrams for systems. Model
-the elements you need. If you want to mix and match, you can even add
-different diagram items to the same diagram to get the view you need.  {%
-endcapture %}
+{% capture about-content %}
 
-{% capture styling-engine %} Customize the diagrams you create with our
-built-in styling engine.  {% endcapture %}
+Gaphor es una aplicación de modelado UML, SysML, RAAML y C4. Está diseñado
+para ser fácil de usar, sin dejar de ser potente. Gaphor implementa un
+modelo de datos UML 2 totalmente compatible, por lo que es mucho más que una
+herramienta de dibujo. Puede usar Gaphor para visualizar rápidamente
+diferentes aspectos de un sistema, así como para crear modelos completos y
+muy complejos.
 
-{% capture treeview %} Easily find all element of your model in the tree
-view.  {% endcapture %}
+{% endcapture %}
 
-{% capture dark-mode %} Love dark mode? We can do that too.  {% endcapture
-%}
+{% capture build %}
 
-{% capture download-content %} There are many ways to install Gaphor.  The
-simplest is to download the official installer for Windows or macOS.  For
-Linux you can install Gaphor using FlatHub.  You can also use Python's
-built-in `pip` tool as long as you have all of the required dependencies
-installed.  {% endcapture %}
+Construya diagramas de clases, interacción y máquinas de estado para el
+software o diagramas de definición de bloques y requisitos para los
+sistemas. Modele los elementos que necesite. Si quiere mezclar y combinar,
+puede incluso añadir diferentes elementos de diagrama al mismo diagrama para
+obtener la vista que necesita.
 
-{% capture blog-content %} Do you want to know what's going on with Gaphor?
-Read our blog!
+{% endcapture %}
+
+{% capture styling-engine %}
+
+Personalice los diagramas que crea con nuestro motor de estilo incorporado.
+
+{% endcapture %}
+
+{% capture treeview %}
+
+Encuentre fácilmente todos los elementos de su modelo en la vista de árbol.
+
+{% endcapture %}
+
+{% capture dark-mode %}
+
+¿Le gusta el modo oscuro? También podemos hacerlo.
+
+{% endcapture %}
+
+{% capture download-content %}
+
+Hay muchas maneras de instalar Gaphor. La más sencilla es descargar el
+instalador oficial para Windows o macOS. Para Linux puede instalar Gaphor
+usando FlatHub.  También puede utilizar la herramienta incorporada de Python
+`pip` siempre que tenga instaladas todas las dependencias necesarias.
+
+{% endcapture %}
+
+{% capture blog-content %}
+
+¿Quiere saber qué pasa con Gaphor? ¡Lea nuestro blog!
 
 [Contact the team]({% link discuss.md %})  if you want to share content
-related to Gaphor.  {% endcapture %}
+related to Gaphor.
 
-{% capture see-blog %} See blog {% endcapture %}
+{% endcapture %}
 
-{% capture read-more %} Read more {% endcapture %}
+{% capture see-blog %}
 
-{% capture download %} Download {% endcapture %}
+Ver blog
 
-{% capture learn %} Learn more {% endcapture %}
+{% endcapture %}
 
-{% capture about %} About {% endcapture %}
+{% capture read-more %}
 
-{% capture download %} Download {% endcapture %}
+Leer más
 
-{% capture tutorials %} Tutorials {% endcapture %}
+{% endcapture %}
 
-{% capture blog %} Blog {% endcapture %}
+{% capture download %}
 
-{% capture discuss %} Get in touch {% endcapture %}
+Descargar
 
-{% capture contribute %} Contribute {% endcapture %}
+{% endcapture %}
+
+{% capture learn %}
+
+Saber más
+
+{% endcapture %}
+
+{% capture about %}
+
+Acerca de
+
+{% endcapture %}
+
+{% capture download %}
+
+Descargar
+
+{% endcapture %}
+
+{% capture tutorials %}
+
+Tutoriales
+
+{% endcapture %}
+
+{% capture blog %}
+
+Blog
+
+{% endcapture %}
+
+{% capture discuss %}
+
+Póngase en contacto
+
+{% endcapture %}
+
+{% capture contribute %}
+
+Contribuir
+
+{% endcapture %}

--- a/es/_includes/footer.md
+++ b/es/_includes/footer.md
@@ -1,12 +1,29 @@
-{% capture love %} We love to hear from you {% endcapture %}
+{% capture love %}
 
-{% capture open-issue %} Open an issue on GitHub {% endcapture %}
+Nos encantaría saber de usted
 
-{% capture tech-docs %}
- Tech docs
 {% endcapture %}
 
-{% capture copyright %} Copyright &copy; 2020-2022 Arjan Molenaar and Dan
-Yeaw.  {% endcapture %}
+{% capture open-issue %}
 
-{% capture theme %} Theme {% endcapture %}
+Abrir una incidencia en GitHub
+
+{% endcapture %}
+
+{% capture tech-docs %}
+
+Documentación técnica
+
+{% endcapture %}
+
+{% capture copyright %}
+
+Copyright &copy; 2020-2022 Arjan Molenaar y Dan Yeaw.
+
+{% endcapture %}
+
+{% capture theme %}
+
+Tema
+
+{% endcapture %}

--- a/es/_platforms/04-python.md
+++ b/es/_platforms/04-python.md
@@ -10,8 +10,8 @@ dependencies installed, you can also install Gaphor using a wheel from
 
 If you don't have the latest stable version of Python and the Gaphor
 dependencies installed, follow the development environment [installation
-instructions](https://gaphor.readthedocs.io/en/latest/)  section, but do not
-clone the repository.  Optionally, create a [virtual
+instructions](https://gaphor.readthedocs.io/en/latest/) section, but do not
+clone the repository. Optionally, create a [virtual
 environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments).
 Then execute the following:
 

--- a/es/contribute.md
+++ b/es/contribute.md
@@ -12,9 +12,9 @@ muchas maneras de contribuir a Gaphor, sin importar su nivel de experiencia
 o habilidades.
 
 Our [technical documentation](https://gaphor.readthedocs.io) is hosted on
-the wonderful service that is [Read the Docs](https://readthedocs.com/).
-Not only does it contain details needed in order to make code contributions
-to Gaphor, but it outlines plenty of other ways in which you can contribute
+the wonderful service that is [Read the Docs](https://readthedocs.com/). Not
+only does it contain details needed in order to make code contributions to
+Gaphor, but it outlines plenty of other ways in which you can contribute
 (including making updates to this website). Finally, it provides a guide to
 our processes and expectations for the various types of contribution you can
 make to Gaphor.

--- a/es/tutorials.md
+++ b/es/tutorials.md
@@ -21,10 +21,11 @@ Michigan Python meetup.
 ## Temas avanzados
 
 - [Extend your models with
-stereotypes](https://gaphor.readthedocs.io/en/latest/stereotypes.html)  -
-[Writing a plugin]({% link tutorials/plugins.md %})  - [Technical and
-architectural documentation](https://gaphor.readthedocs.io/)  for
-contributors and plugin developers
+  stereotypes](https://gaphor.readthedocs.io/en/latest/stereotypes.html)
+- [Writing a plugin]({% link tutorials/plugins.md %})
+- [Technical and architectural
+documentation](https://gaphor.readthedocs.io/)  for contributors and plugin
+developers
 
 ## Charlas
 
@@ -45,8 +46,8 @@ There are some 10+ year old articles on Gaphor on the web. Some more recent
 articles are:
 
 - [Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on
-a Window 10.](https://www.methodsandtools.com/tools/gaphor.php)  - [It's
-FOSS has a short write-up on Gaphor
-(~2.8-ish?).](https://itsfoss.com/gaphor-modeling-tool/)  - [Ubuntu Pit has
-a nice article on Gaphor
-(~2.8-ish?).](https://www.ubuntupit.com/gaphor-an-open-source-simple-graphical-modeling-tool/)
+  a Window 10.](https://www.methodsandtools.com/tools/gaphor.php)
+- [It's FOSS has a short write-up on Gaphor
+  (~2.8-ish?).](https://itsfoss.com/gaphor-modeling-tool/)
+- [Ubuntu Pit has a nice article on Gaphor
+  (~2.8-ish?).](https://www.ubuntupit.com/gaphor-an-open-source-simple-graphical-modeling-tool/)

--- a/es/tutorials/plugins.md
+++ b/es/tutorials/plugins.md
@@ -5,6 +5,7 @@ layout: article
 redirect_from: /pages/writing-a-plugin.html
 title: 'Escribir un plugin'
 ---
+
 Gaphor está diseñado para ser extensible mediante el uso de plugins que
 permiten ampliar la funcionalidad.
 

--- a/hr/_includes/content.md
+++ b/hr/_includes/content.md
@@ -1,59 +1,122 @@
-{% capture thousand-words %} A picture is worth a thousand words. Describe
-and document your applications and systems with Gaphor to enhance knowledge
-sharing.  {% endcapture %}
+{% capture thousand-words %}
 
-{% capture about-content %} Gaphor is a UML, SysML, RAAML, and C4 modeling
-application. It is designed to be easy to use, while still being
-powerful. Gaphor implements a fully-compliant UML 2 data model, so it is
-much more than a picture drawing tool. You can use Gaphor to quickly
-visualize different aspects of a system as well as create complete, highly
-complex models.
+Slika vrijedi tisuću riječi. Opiši i dokumentiraj svoje programe i sustave s
+Gaphorom za poboljšavanje dijeljenja znanja.
 
 {% endcapture %}
 
-{% capture build %} Build Class, Interaction, and State Machine diagrams for
-software or Block Definition and Requirements diagrams for systems. Model
-the elements you need. If you want to mix and match, you can even add
-different diagram items to the same diagram to get the view you need.  {%
-endcapture %}
+{% capture about-content %}
 
-{% capture styling-engine %} Customize the diagrams you create with our
-built-in styling engine.  {% endcapture %}
+Gaphor je UML, SYSML, Raaml i C4 program za modeliranje. Izrađen je kao
+jednostavan i moćan program. Gaphor implementira potpuno sukladan UML 2
+model podataka, tako da je program više od običnog alata za crtanje
+slike. Koristi Gaphor za brzo vizualiziranje različitih aspekata sustava,
+kao i za stvaranje potpunih, vrlo složenih modela.
 
-{% capture treeview %} Easily find all element of your model in the tree
-view.  {% endcapture %}
+{% endcapture %}
 
-{% capture dark-mode %} Love dark mode? We can do that too.  {% endcapture
-%}
+{% capture build %}
 
-{% capture download-content %} There are many ways to install Gaphor.  The
-simplest is to download the official installer for Windows or macOS.  For
-Linux you can install Gaphor using FlatHub.  You can also use Python's
-built-in `pip` tool as long as you have all of the required dependencies
-installed.  {% endcapture %}
+Izradi klase, interakciju i dijagrame stanja uređaja za softver ili
+dijagrame definicija blokova i dijagrame preduvjeta za sustave. Modeliraj
+elemente koje trebaš. Ako želiš miješati i uskladiti, za dobivanje željenog
+prikaza istom dijagramu možeš čak dodati različite elemente dijagrama.
 
-{% capture blog-content %} Do you want to know what's going on with Gaphor?
-Read our blog!
+{% endcapture %}
+
+{% capture styling-engine %}
+
+Prilagodi dijagrame koje stvaraš pomoću našeg ugrađenog mehanizma za
+stiliziranje.
+
+{% endcapture %}
+
+{% capture treeview %}
+
+Pronađi sve elemente tvog modela na jednostavan način u prikazu stabla.
+
+{% endcapture %}
+
+{% capture dark-mode %}
+
+Voliš tamni modus? Omogućujemo i to.
+
+{% endcapture %}
+
+{% capture download-content %}
+
+Postoji mnogo načina za instaliranje Gaphora. Najjednostavnije je preuzeti
+službeni instalacijski program za Windows ili macOS. Za Linux se Gaphor može
+instalirati koristeći FlatHub. Također je moguće koristiti Pythonov ugrađeni
+`pip` alat ukoliko su sve potrebne ovisnosti instalirane.
+
+{% endcapture %}
+
+{% capture blog-content %}
+
+Želiš znati što se događa s Gaphorom? Čitaj naš blog!
 
 [Contact the team]({% link discuss.md %})  if you want to share content
-related to Gaphor.  {% endcapture %}
+related to Gaphor.
 
-{% capture see-blog %} See blog {% endcapture %}
+{% endcapture %}
 
-{% capture read-more %} Read more {% endcapture %}
+{% capture see-blog %}
 
-{% capture download %} Download {% endcapture %}
+Pogledaj blog
 
-{% capture learn %} Learn more {% endcapture %}
+{% endcapture %}
 
-{% capture about %} About {% endcapture %}
+{% capture read-more %}
 
-{% capture download %} Download {% endcapture %}
+Saznaj više
 
-{% capture tutorials %} Tutorials {% endcapture %}
+{% endcapture %}
 
-{% capture blog %} Blog {% endcapture %}
+{% capture download %}
 
-{% capture discuss %} Get in touch {% endcapture %}
+Preuzmi
 
-{% capture contribute %} Contribute {% endcapture %}
+{% endcapture %}
+
+{% capture learn %}
+
+Saznaj više
+
+{% endcapture %}
+
+{% capture about %}
+
+Informacije
+
+{% endcapture %}
+
+{% capture download %}
+
+Preuzmi
+
+{% endcapture %}
+
+{% capture tutorials %}
+
+Vježbe
+
+{% endcapture %}
+
+{% capture blog %}
+
+Blog
+
+{% endcapture %}
+
+{% capture discuss %}
+
+Kontaktiraj zajednicu
+
+{% endcapture %}
+
+{% capture contribute %}
+
+Doprinesi
+
+{% endcapture %}

--- a/hr/_includes/footer.md
+++ b/hr/_includes/footer.md
@@ -1,12 +1,29 @@
-{% capture love %} We love to hear from you {% endcapture %}
+{% capture love %}
 
-{% capture open-issue %} Open an issue on GitHub {% endcapture %}
+Radujemo se tvom javljanju
 
-{% capture tech-docs %}
- Tech docs
 {% endcapture %}
 
-{% capture copyright %} Copyright &copy; 2020-2022 Arjan Molenaar and Dan
-Yeaw.  {% endcapture %}
+{% capture open-issue %}
 
-{% capture theme %} Theme {% endcapture %}
+Prijavi problem na GitHubu
+
+{% endcapture %}
+
+{% capture tech-docs %}
+
+Tehnička dokumentacija
+
+{% endcapture %}
+
+{% capture copyright %}
+
+Autorska prava &copy; 2020. – 2022. Arjan Molenaar i Dan Yeaw.
+
+{% endcapture %}
+
+{% capture theme %}
+
+Tema
+
+{% endcapture %}

--- a/hr/_platforms/04-python.md
+++ b/hr/_platforms/04-python.md
@@ -10,8 +10,8 @@ dependencies installed, you can also install Gaphor using a wheel from
 
 If you don't have the latest stable version of Python and the Gaphor
 dependencies installed, follow the development environment [installation
-instructions](https://gaphor.readthedocs.io/en/latest/)  section, but do not
-clone the repository.  Optionally, create a [virtual
+instructions](https://gaphor.readthedocs.io/en/latest/) section, but do not
+clone the repository. Optionally, create a [virtual
 environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments).
 Then execute the following:
 

--- a/hr/contribute.md
+++ b/hr/contribute.md
@@ -11,9 +11,9 @@ programere, ne brini. Postoji mnogo načina kako doprinijeti Gaphoru, bez
 obzira na razinu iskustva ili vještine.
 
 Our [technical documentation](https://gaphor.readthedocs.io) is hosted on
-the wonderful service that is [Read the Docs](https://readthedocs.com/).
-Not only does it contain details needed in order to make code contributions
-to Gaphor, but it outlines plenty of other ways in which you can contribute
+the wonderful service that is [Read the Docs](https://readthedocs.com/). Not
+only does it contain details needed in order to make code contributions to
+Gaphor, but it outlines plenty of other ways in which you can contribute
 (including making updates to this website). Finally, it provides a guide to
 our processes and expectations for the various types of contribution you can
 make to Gaphor.

--- a/hr/tutorials.md
+++ b/hr/tutorials.md
@@ -21,10 +21,11 @@ Michigan Python meetup.
 ## Napredne teme
 
 - [Extend your models with
-stereotypes](https://gaphor.readthedocs.io/en/latest/stereotypes.html)  -
-[Writing a plugin]({% link tutorials/plugins.md %})  - [Technical and
-architectural documentation](https://gaphor.readthedocs.io/)  for
-contributors and plugin developers
+  stereotypes](https://gaphor.readthedocs.io/en/latest/stereotypes.html)
+- [Writing a plugin]({% link tutorials/plugins.md %})
+- [Technical and architectural
+documentation](https://gaphor.readthedocs.io/)  for contributors and plugin
+developers
 
 ## Predavanja
 
@@ -45,8 +46,8 @@ There are some 10+ year old articles on Gaphor on the web. Some more recent
 articles are:
 
 - [Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on
-a Window 10.](https://www.methodsandtools.com/tools/gaphor.php)  - [It's
-FOSS has a short write-up on Gaphor
-(~2.8-ish?).](https://itsfoss.com/gaphor-modeling-tool/)  - [Ubuntu Pit has
-a nice article on Gaphor
-(~2.8-ish?).](https://www.ubuntupit.com/gaphor-an-open-source-simple-graphical-modeling-tool/)
+  a Window 10.](https://www.methodsandtools.com/tools/gaphor.php)
+- [It's FOSS has a short write-up on Gaphor
+  (~2.8-ish?).](https://itsfoss.com/gaphor-modeling-tool/)
+- [Ubuntu Pit has a nice article on Gaphor
+  (~2.8-ish?).](https://www.ubuntupit.com/gaphor-an-open-source-simple-graphical-modeling-tool/)

--- a/hr/tutorials/plugins.md
+++ b/hr/tutorials/plugins.md
@@ -5,6 +5,7 @@ layout: article
 redirect_from: /pages/writing-a-plugin.html
 title: 'Pisanje dodatka'
 ---
+
 Gaphor je izrađen tako da se može proširiti korištenjem dodataka koji
 omogućuju dodatnu funkcionalnost.
 

--- a/hu/_includes/content.md
+++ b/hu/_includes/content.md
@@ -1,59 +1,122 @@
-{% capture thousand-words %} A picture is worth a thousand words. Describe
-and document your applications and systems with Gaphor to enhance knowledge
-sharing.  {% endcapture %}
+{% capture thousand-words %}
 
-{% capture about-content %} Gaphor is a UML, SysML, RAAML, and C4 modeling
-application. It is designed to be easy to use, while still being
-powerful. Gaphor implements a fully-compliant UML 2 data model, so it is
-much more than a picture drawing tool. You can use Gaphor to quickly
-visualize different aspects of a system as well as create complete, highly
-complex models.
+Egy kép többet ér ezer szónál. Ismertesse és dokumentálja alkalmazásait és
+rendszereit a Gaphor segítségével a tudásmegosztás javítása érdekében.
 
 {% endcapture %}
 
-{% capture build %} Build Class, Interaction, and State Machine diagrams for
-software or Block Definition and Requirements diagrams for systems. Model
-the elements you need. If you want to mix and match, you can even add
-different diagram items to the same diagram to get the view you need.  {%
-endcapture %}
+{% capture about-content %}
 
-{% capture styling-engine %} Customize the diagrams you create with our
-built-in styling engine.  {% endcapture %}
+A Gaphor egy UML-, SysML-, RAAML- és C4-modellező-alkalmazás. Úgy tervezték,
+hogy könnyen használható legyen, ugyanakkor erős legyen. A Gaphor egy
+teljesen kompatibilis UML 2 adatmodellt valósít meg, tehát sokkal több, mint
+egy képrajzoló eszköz. A Gaphor segítségével gyorsan megjelenítheti a
+rendszer különböző aspektusait, valamint komplett, rendkívül összetett
+modelleket hozhat létre.
 
-{% capture treeview %} Easily find all element of your model in the tree
-view.  {% endcapture %}
+{% endcapture %}
 
-{% capture dark-mode %} Love dark mode? We can do that too.  {% endcapture
-%}
+{% capture build %}
 
-{% capture download-content %} There are many ways to install Gaphor.  The
-simplest is to download the official installer for Windows or macOS.  For
-Linux you can install Gaphor using FlatHub.  You can also use Python's
-built-in `pip` tool as long as you have all of the required dependencies
-installed.  {% endcapture %}
+Build Class, Interaction, and State Machine diagrams for software or Block
+Definition and Requirements diagrams for systems. Model the elements you
+need. If you want to mix and match, you can even add different diagram items
+to the same diagram to get the view you need.
 
-{% capture blog-content %} Do you want to know what's going on with Gaphor?
-Read our blog!
+{% endcapture %}
+
+{% capture styling-engine %}
+
+Customize the diagrams you create with our built-in styling engine.
+
+{% endcapture %}
+
+{% capture treeview %}
+
+Easily find all element of your model in the tree view.
+
+{% endcapture %}
+
+{% capture dark-mode %}
+
+Love dark mode? We can do that too.
+
+{% endcapture %}
+
+{% capture download-content %}
+
+There are many ways to install Gaphor.  The simplest is to download the
+official installer for Windows or macOS.  For Linux you can install Gaphor
+using FlatHub.  You can also use Python's built-in `pip` tool as long as you
+have all the required dependencies installed.
+
+{% endcapture %}
+
+{% capture blog-content %}
+
+Szeretnéd tudni, mi történik Gaphorral? Olvassa el naplónkat!
 
 [Contact the team]({% link discuss.md %})  if you want to share content
-related to Gaphor.  {% endcapture %}
+related to Gaphor.
 
-{% capture see-blog %} See blog {% endcapture %}
+{% endcapture %}
 
-{% capture read-more %} Read more {% endcapture %}
+{% capture see-blog %}
 
-{% capture download %} Download {% endcapture %}
+Napló megtekintése
 
-{% capture learn %} Learn more {% endcapture %}
+{% endcapture %}
 
-{% capture about %} About {% endcapture %}
+{% capture read-more %}
 
-{% capture download %} Download {% endcapture %}
+Read more
 
-{% capture tutorials %} Tutorials {% endcapture %}
+{% endcapture %}
 
-{% capture blog %} Blog {% endcapture %}
+{% capture download %}
 
-{% capture discuss %} Get in touch {% endcapture %}
+Letöltés
 
-{% capture contribute %} Contribute {% endcapture %}
+{% endcapture %}
+
+{% capture learn %}
+
+További tájékoztatás
+
+{% endcapture %}
+
+{% capture about %}
+
+Rólunk
+
+{% endcapture %}
+
+{% capture download %}
+
+Letöltés
+
+{% endcapture %}
+
+{% capture tutorials %}
+
+Oktatóanyagok
+
+{% endcapture %}
+
+{% capture blog %}
+
+Napló
+
+{% endcapture %}
+
+{% capture discuss %}
+
+Kapcsolatfelvétel
+
+{% endcapture %}
+
+{% capture contribute %}
+
+Közreműködés
+
+{% endcapture %}

--- a/hu/_includes/footer.md
+++ b/hu/_includes/footer.md
@@ -1,12 +1,29 @@
-{% capture love %} We love to hear from you {% endcapture %}
+{% capture love %}
 
-{% capture open-issue %} Open an issue on GitHub {% endcapture %}
+We love to hear from you
 
-{% capture tech-docs %}
- Tech docs
 {% endcapture %}
 
-{% capture copyright %} Copyright &copy; 2020-2022 Arjan Molenaar and Dan
-Yeaw.  {% endcapture %}
+{% capture open-issue %}
 
-{% capture theme %} Theme {% endcapture %}
+Probléma megnyitása a GitHubon
+
+{% endcapture %}
+
+{% capture tech-docs %}
+
+Tech docs
+
+{% endcapture %}
+
+{% capture copyright %}
+
+Szerzői jog &copy; 2020-2022 Molenaar Arjan és Yeaw Dániel.
+
+{% endcapture %}
+
+{% capture theme %}
+
+Theme
+
+{% endcapture %}

--- a/hu/_platforms/04-python.md
+++ b/hu/_platforms/04-python.md
@@ -10,8 +10,8 @@ dependencies installed, you can also install Gaphor using a wheel from
 
 If you don't have the latest stable version of Python and the Gaphor
 dependencies installed, follow the development environment [installation
-instructions](https://gaphor.readthedocs.io/en/latest/)  section, but do not
-clone the repository.  Optionally, create a [virtual
+instructions](https://gaphor.readthedocs.io/en/latest/) section, but do not
+clone the repository. Optionally, create a [virtual
 environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments).
 Then execute the following:
 

--- a/hu/contribute.md
+++ b/hu/contribute.md
@@ -12,9 +12,9 @@ are plenty of ways to contribute to Gaphor, no matter your level of
 experience or skill set.
 
 Our [technical documentation](https://gaphor.readthedocs.io) is hosted on
-the wonderful service that is [Read the Docs](https://readthedocs.com/).
-Not only does it contain details needed in order to make code contributions
-to Gaphor, but it outlines plenty of other ways in which you can contribute
+the wonderful service that is [Read the Docs](https://readthedocs.com/). Not
+only does it contain details needed in order to make code contributions to
+Gaphor, but it outlines plenty of other ways in which you can contribute
 (including making updates to this website). Finally, it provides a guide to
 our processes and expectations for the various types of contribution you can
 make to Gaphor.

--- a/hu/download.md
+++ b/hu/download.md
@@ -14,7 +14,7 @@ title: 'A Gaphor letöltése'
 There are many ways to install Gaphor. The simplest is to download the
 official installer for Windows or macOS. For Linux you can install Gaphor
 using FlatHub.  You can also use Python's built-in `pip` tool as long as you
-have all of the required dependencies installed.
+have all the required dependencies installed.
 
 If you're a developer, you can find the source code [on
 GitHub](https://github.com/gaphor/gaphor).

--- a/hu/tutorials.md
+++ b/hu/tutorials.md
@@ -21,10 +21,11 @@ Michigan Python meetup.
 ## Advanced topics
 
 - [Extend your models with
-stereotypes](https://gaphor.readthedocs.io/en/latest/stereotypes.html)  -
-[Writing a plugin]({% link tutorials/plugins.md %})  - [Technical and
-architectural documentation](https://gaphor.readthedocs.io/)  for
-contributors and plugin developers
+  stereotypes](https://gaphor.readthedocs.io/en/latest/stereotypes.html)
+- [Writing a plugin]({% link tutorials/plugins.md %})
+- [Technical and architectural
+documentation](https://gaphor.readthedocs.io/)  for contributors and plugin
+developers
 
 ## Talks
 
@@ -45,8 +46,8 @@ There are some 10+ year old articles on Gaphor on the web. Some more recent
 articles are:
 
 - [Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on
-a Window 10.](https://www.methodsandtools.com/tools/gaphor.php)  - [It's
-FOSS has a short write-up on Gaphor
-(~2.8-ish?).](https://itsfoss.com/gaphor-modeling-tool/)  - [Ubuntu Pit has
-a nice article on Gaphor
-(~2.8-ish?).](https://www.ubuntupit.com/gaphor-an-open-source-simple-graphical-modeling-tool/)
+  a Window 10.](https://www.methodsandtools.com/tools/gaphor.php)
+- [It's FOSS has a short write-up on Gaphor
+  (~2.8-ish?).](https://itsfoss.com/gaphor-modeling-tool/)
+- [Ubuntu Pit has a nice article on Gaphor
+  (~2.8-ish?).](https://www.ubuntupit.com/gaphor-an-open-source-simple-graphical-modeling-tool/)

--- a/hu/tutorials/plugins.md
+++ b/hu/tutorials/plugins.md
@@ -5,6 +5,7 @@ layout: article
 redirect_from: /pages/writing-a-plugin.html
 title: 'Writing a Plugin'
 ---
+
 Gaphor is designed to be extensible by using plugins that allow you to
 extend the functionality.
 
@@ -39,7 +40,7 @@ Two methods are used for querying:
 -   `lselect(query=None)` -> returns a list
 
 `query` is a lambda function with the element as parameter. For example, to
-fetch all of the Class instances from the element factory:
+fetch all the Class instances from the element factory:
 
 ```python
 element_factory.select(lambda e: e.isKindOf(UML.Class))

--- a/hu/tutorials/report-bugs.md
+++ b/hu/tutorials/report-bugs.md
@@ -43,8 +43,8 @@ Use plain and simple language to describe the problem and, if helpful, break
 it down into steps so developers can easily recreate the issue. Please don't
 assume we'll understand what you were trying to achieve -- honestly, it's
 best if you try to imagine we (the developers) are a bunch of clever
-5-year-olds.  Try to explain *everything* about the problem and don't assume
-we know what you mean. We won't mind!
+5-year-olds. Try to explain *everything* about the problem and don't assume
+we know what you mean.  We won't mind!
 
 If you would like to get more involved in the development of Gaphor, we'd
 love to welcome you via the [Gaphor developer's

--- a/hu/tutorials/your-first-model.md
+++ b/hu/tutorials/your-first-model.md
@@ -25,7 +25,7 @@ collapsed and needs to be clicked first to reveal its contents.
 Gaphor does not make any assumptions about which elements should be placed
 on a diagram. A diagram is a diagram. UML defines all different kinds of
 diagrams, such as Class diagrams, Component diagrams, Action diagrams,
-Sequence diagrams. But Gaphor does not place any restrictions.
+Sequence diagrams.  But Gaphor does not place any restrictions.
 
 ## Creating New Diagrams
 
@@ -34,7 +34,7 @@ Sequence diagrams. But Gaphor does not place any restrictions.
 To create a new diagram, use the Navigation section. Select an element that
 can contain a diagram (a Package or Profile) and right-click. Select New
 diagram and a new diagram is created. As of Gaphor 1.1.0 a buttion is
-available in the header bar. Select a package and you'll notice the button
+available in the header bar. Select a package, and you'll notice the button
 is not grayed out and can be clicked, resulting in a new diagram being added
 to the model.
 
@@ -45,7 +45,7 @@ another). A paste will create new items in the diagrams, the items they
 represent (e.g. the Class that's shown in the Navigation) is *not* copied
 (call it a shallow copy if you like).
 
-This way you can easely create visual copies of the same (underlaying) model
+This way you can easily create visual copies of the same (underlying) model
 element.
 
 ## Drag and Drop

--- a/po/build.py
+++ b/po/build.py
@@ -7,9 +7,9 @@ language.
 3. Remove filt files created with the filter-markdown.py script.
 """
 
-import pathlib
 import re
 import subprocess
+from pathlib import Path
 
 # HTML tags like <img src="images/matrix_org.svg" alt="matrix.org" style="height: 1em" />
 html_tags = r"(<!--.*?-->|<[^>]*>)"
@@ -35,15 +35,15 @@ def strip_markdown_urls(markdown):
 
 
 def replace_language_string():
-    conf_file = pathlib.Path("po") / "po4a.conf"
+    conf_file = Path("po") / "po4a.conf"
     with conf_file.open() as f:
         line = f.readline()
         pattern = "\[po4a_langs\] (.*)"
         match = re.search(pattern, line)
-        languages = match.group(1).split()
+        languages = match[1].split()
 
     for language in languages:
-        markdown_files = pathlib.Path(language).glob("**/*.md")
+        markdown_files = Path(language).glob("**/*.md")
         for file in markdown_files:
             with file.open("r") as f:
                 lines = f.readlines()
@@ -55,14 +55,14 @@ def replace_language_string():
 
 
 def cleanup_filt_files():
-    filt_files = pathlib.Path(".").glob("**/*.filt")
+    filt_files = Path(".").glob("**/*.filt")
     for file in filt_files:
         file.unlink()
 
 
 if __name__ == "__main__":
     print("Filtering markdown before po4a conversion")
-    p = pathlib.Path(__file__).parent.parent.resolve()
+    p = Path(__file__).parent.parent.resolve()
     for f in p.glob("**/*.md"):
         stripped = strip_markdown_urls(f.read_text(encoding="utf-8"))
         compiled_re = re.compile("|".join(re_list), re.MULTILINE)

--- a/po/site.cs.po
+++ b/po/site.cs.po
@@ -6,17 +6,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-15 21:11-0300\n"
-"PO-Revision-Date: 2023-01-18 14:49+0000\n"
+"POT-Creation-Date: 2023-01-22 16:01-0500\n"
+"PO-Revision-Date: 2022-10-23 16:05+0000\n"
 "Last-Translator: vikdevelop <super-vik1@protonmail.com>\n"
-"Language-Team: Czech <https://hosted.weblate.org/projects/gaphor/"
-"gaphor-github-io/cs/>\n"
+"Language-Team: Czech <https://hosted.weblate.org/projects/gaphor/gaphor-github-io/cs/>\n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
-"X-Generator: Weblate 4.15.1-dev\n"
+"X-Generator: Weblate 4.14.2-dev\n"
 
 #. type: Plain text
 #: _includes/footer.md.filt
@@ -30,13 +29,12 @@ msgstr "Otevřete problém na GitHubu"
 
 #. type: Plain text
 #: _includes/footer.md.filt
-#, no-wrap
-msgid " Tech docs\n"
-msgstr " Technické dokumenty\n"
+msgid "Tech docs"
+msgstr "Technické dokumenty"
 
 #. type: Plain text
 #: _includes/footer.md.filt
-msgid "Copyright &copy; 2020-2022 Arjan Molenaar and Dan Yeaw."
+msgid "Copyright &copy; 2020-2023 Arjan Molenaar and Dan Yeaw."
 msgstr "Copyright &copy; 2020-2022 Arjan Molenaar a Dan Yeaw."
 
 #. type: Plain text
@@ -76,8 +74,8 @@ msgstr "Milujete tmavý režim? I ten umíme."
 
 #. type: Plain text
 #: _includes/content.md.filt
-msgid "There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
-msgstr "Existuje mnoho způsobů instalace systému Gaphor.  Nejjednodušší je stáhnout si oficiální instalační program pro Windows nebo macOS.  Na Linux je možné nainstalovat Gaphor pomocí FlatHubu.  Můžete také použít vestavěný nástroj `pip` pro Python, pokud máte nainstalovány všechny potřebné závislosti."
+msgid "There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all the required dependencies installed."
+msgstr "Existuje mnoho způsobů instalace systému Gaphor. Nejjednodušší je stáhnout si oficiální instalační program pro Windows nebo macOS. Pro Linux můžete Gaphor nainstalovat pomocí FlatHubu.  Můžete také použít vestavěný nástroj `pip` pro Python, pokud máte nainstalovány všechny potřebné závislosti."
 
 #. type: Plain text
 #: _includes/content.md.filt
@@ -114,7 +112,7 @@ msgstr "Zjistěte více"
 msgid "About"
 msgstr "O nás"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt tutorials.md.filt
 #, no-wrap
 msgid "Tutorials"
@@ -125,19 +123,19 @@ msgstr "Tutoriály"
 msgid "Blog"
 msgstr "Blog"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt discuss.md.filt
 #, no-wrap
 msgid "Get in touch"
 msgstr "Spojte se s námi"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt contribute.md.filt
 #, no-wrap
 msgid "Contribute"
 msgstr "Přispět"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/01-windows.md.filt
 #, no-wrap
 msgid "Windows"
@@ -160,7 +158,7 @@ msgstr "Případně si můžete stáhnout přenosnou verzi programu Gaphor."
 msgid " Download portable version\n"
 msgstr " Stáhnout přenosnou verzi\n"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/02-macos.md.filt
 #, no-wrap
 msgid "macOS"
@@ -175,7 +173,7 @@ msgstr " Stáhnout .dmg\n"
 #. type: Plain text
 #: _platforms/02-macos.md.filt
 msgid "Gaphor requires **macOS 10.15** or newer."
-msgstr "Gaphor vyžaduje **macOS 10.15** nebo novější."
+msgstr ""
 
 #. type: Title ###
 #: _platforms/02-macos.md.filt
@@ -188,7 +186,7 @@ msgstr "Homebrew"
 msgid "Pour Gaphor from a homebrew cask:"
 msgstr "Nalijte Gaphor z domácího sudu:"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/03-linux.md.filt
 #, no-wrap
 msgid "Linux"
@@ -231,8 +229,6 @@ msgstr " Stáhnout AppImage\n"
 #: _platforms/03-linux.md.filt
 msgid "If you're using Wayland and the AppImage crashes, you can force it to use the X11 backend instead."
 msgstr ""
-"Pokud používáte Wayland a dojde k pádu AppImage, můžete jej donutit, aby "
-"místo toho používal backend X11."
 
 #. type: Title ###
 #: _platforms/03-linux.md.filt
@@ -245,7 +241,7 @@ msgstr "Arch Linux"
 msgid "Gaphor can be installed from an AUR package."
 msgstr "Gaphor lze nainstalovat jako balíček z AUR repositáře."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/04-python.md.filt
 #, no-wrap
 msgid "Python"
@@ -258,10 +254,10 @@ msgstr "Pokud máte nainstalovanou nejnovější stabilní verzi Pythonu a závi
 
 #. type: Plain text
 #: _platforms/04-python.md.filt
-msgid "If you don't have the latest stable version of Python and the Gaphor dependencies installed, follow the development environment installation instructions section, but do not clone the repository.  Optionally, create a virtual environment.  Then execute the following:"
+msgid "If you don't have the latest stable version of Python and the Gaphor dependencies installed, follow the development environment installation instructions section, but do not clone the repository. Optionally, create a virtual environment.  Then execute the following:"
 msgstr "Pokud nemáte nainstalovanou nejnovější stabilní verzi Pythonu a závislostí Gaphor, postupujte podle pokynů pro instalaci vývojového prostředí, ale neklonujte úložiště.  Případně vytvořte virtuální prostředí.  Poté proveďte následující příkaz:"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: tutorials/plugins.md.filt
 #, no-wrap
 msgid "Writing a Plugin"
@@ -311,7 +307,7 @@ msgstr "`lselect(query=None)` -> vrací seznam"
 
 #. type: Plain text
 #: tutorials/plugins.md.filt
-msgid "`query` is a lambda function with the element as parameter. For example, to fetch all of the Class instances from the element factory:"
+msgid "`query` is a lambda function with the element as parameter. For example, to fetch all the Class instances from the element factory:"
 msgstr "`dotaz` je lambda funkce s prvkem jako parametrem. Například pro načtení všech instancí třídy z továrny na prvky:"
 
 #. type: Title ##
@@ -351,7 +347,7 @@ msgstr "Příklad pluginu"
 msgid "An example Hello World plugin is hosted on GitHub."
 msgstr "Příklad zásuvného modulu Hello World je umístěn na GitHubu."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: tutorials/report-bugs.md.filt
 #, no-wrap
 msgid "How to report a bug in Gaphor"
@@ -424,7 +420,7 @@ msgstr "Technické údaje, jako je verze programu Gaphor, kterou používáte, v
 
 #. type: Plain text
 #: tutorials/report-bugs.md.filt
-msgid "Use plain and simple language to describe the problem and, if helpful, break it down into steps so developers can easily recreate the issue. Please don't assume we'll understand what you were trying to achieve -- honestly, it's best if you try to imagine we (the developers) are a bunch of clever 5-year-olds.  Try to explain *everything* about the problem and don't assume we know what you mean. We won't mind!"
+msgid "Use plain and simple language to describe the problem and, if helpful, break it down into steps so developers can easily recreate the issue. Please don't assume we'll understand what you were trying to achieve -- honestly, it's best if you try to imagine we (the developers) are a bunch of clever 5-year-olds. Try to explain *everything* about the problem and don't assume we know what you mean.  We won't mind!"
 msgstr "Problém popište jednoduchým a srozumitelným jazykem, a pokud je to užitečné, rozdělte jej do jednotlivých kroků, aby vývojáři mohli problém snadno znovu vytvořit. Nepředpokládejte, že pochopíme, čeho jste se snažili dosáhnout - upřímně řečeno, nejlepší bude, když si zkusíte představit, že my (vývojáři) jsme banda chytrých pětiletých dětí.  Pokuste se vysvětlit *vše* o problému a nepředpokládejte, že víme, co máte na mysli. Nebude nám to vadit!"
 
 #. type: Plain text
@@ -580,7 +576,7 @@ msgstr "Některé prvky nejsou přímo viditelné. Sekce ve schránce nástrojů
 
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
-msgid "Gaphor does not make any assumptions about which elements should be placed on a diagram. A diagram is a diagram. UML defines all different kinds of diagrams, such as Class diagrams, Component diagrams, Action diagrams, Sequence diagrams. But Gaphor does not place any restrictions."
+msgid "Gaphor does not make any assumptions about which elements should be placed on a diagram. A diagram is a diagram. UML defines all different kinds of diagrams, such as Class diagrams, Component diagrams, Action diagrams, Sequence diagrams.  But Gaphor does not place any restrictions."
 msgstr "Gaphor nevytváří žádné předpoklady o tom, které prvky by měly být umístěny v diagramu. Diagram je diagram. UML definuje všechny různé druhy diagramů, jako jsou diagramy tříd, diagramy komponent, diagramy akcí, diagramy sekvencí. Gaphor však neklade žádná omezení."
 
 #. type: Title ##
@@ -591,7 +587,7 @@ msgstr "Vytváření nových diagramů"
 
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
-msgid "To create a new diagram, use the Navigation section. Select an element that can contain a diagram (a Package or Profile) and right-click. Select New diagram and a new diagram is created. As of Gaphor 1.1.0 a buttion is available in the header bar. Select a package and you'll notice the button is not grayed out and can be clicked, resulting in a new diagram being added to the model."
+msgid "To create a new diagram, use the Navigation section. Select an element that can contain a diagram (a Package or Profile) and right-click. Select New diagram and a new diagram is created. As of Gaphor 1.1.0 a buttion is available in the header bar. Select a package, and you'll notice the button is not grayed out and can be clicked, resulting in a new diagram being added to the model."
 msgstr "Chcete-li vytvořit nový diagram, použijte část Navigace. Vyberte prvek, který může obsahovat diagram (balíček nebo profil) a klikněte pravým tlačítkem. Vyberte Nový diagram a vytvoří se nový diagram. Od Verze Gaphor 1.1.0 je v záhlaví k dispozici buttion. Vyberte balíček a všimnete si, že tlačítko není zobrazeno šedě a lze na něj kliknout, což má za následek přidání nového diagramu do modelu."
 
 #. type: Title ##
@@ -607,7 +603,7 @@ msgstr "Položky v diagramu lze kopírovat a vkládat (do stejného nebo jiného
 
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
-msgid "This way you can easely create visual copies of the same (underlaying) model element."
+msgid "This way you can easily create visual copies of the same (underlying) model element."
 msgstr "Tímto způsobem můžete snadno vytvářet vizuální kopie stejného (podkladového) prvku modelu."
 
 #. type: Title ##
@@ -626,7 +622,7 @@ msgstr "Přidání existujícího prvku do diagramu je jednoduché: přetáhnět
 msgid "Elements can also be dragged within the Navigation section. This way classes and packages can be rearranged for example."
 msgstr "Prvky lze přetahovat také v rámci sekce Navigace. Tímto způsobem lze například přeskupovat třídy a balíčky."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/01-platform.md.filt
 #, no-wrap
 msgid "Multi-platform"
@@ -637,7 +633,7 @@ msgstr "Multiplatformní"
 msgid "Gaphor works on all major platforms: Windows, Macos and Linux."
 msgstr "Gaphor funguje na všech hlavních platformách: Windows, macOS a Linux."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/02-opensource.md.filt
 #, no-wrap
 msgid "Open Source"
@@ -648,7 +644,7 @@ msgstr "Otevřený zdrojový kód"
 msgid "No vendor lock-in: Gaphor written in Python and is 100% Open Source, available under a friendly Apache 2 license."
 msgstr "Žádný vendor lock-in: Gaphor je napsán v jazyce Python a je 100% open source, dostupný pod přátelskou licencí Apache 2."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/03-beginner-pro.md.filt
 #, no-wrap
 msgid "Beginner or Pro"
@@ -659,7 +655,7 @@ msgstr "Začátečník nebo profesionál"
 msgid "Whether you're a casual modeler documenting a project or a Model Driven Development expert, Gaphor has got you covered."
 msgstr "Ať už jste příležitostný modelář, který dokumentuje projekt, nebo expert na vývoj řízený modelem, Gaphor vám pomůže."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/04-consistent.md.filt
 #, no-wrap
 msgid "Consistent"
@@ -670,7 +666,7 @@ msgstr "Konzistentní"
 msgid "UML is a graphical modeling language, so all information you put in the model is visible in the diagrams. For example, stereotypes are modeled in diagrams.  No hidden panels and property pages. Just diagrams!"
 msgstr "UML je grafický modelovací jazyk, takže všechny informace, které do modelu vložíte, jsou viditelné v diagramech. Například stereotypy jsou modelovány v diagramech.  Žádné skryté panely a stránky vlastností. Jen diagramy!"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/05-extensible.md.filt
 #, no-wrap
 msgid "Extensible"
@@ -681,7 +677,7 @@ msgstr "Rozšiřitelný"
 msgid "Gaphor is extensible. Plug-in a code generator or export your diagrams for documentation.  Create your own extensions and access them through the GUI or CLI."
 msgstr "Gaphor je rozšiřitelný. Připojte generátor kódu nebo exportujte svá schémata pro dokumentaci.  Vytvořte si vlastní rozšíření a přistupujte k nim prostřednictvím grafického uživatelského rozhraní nebo rozhraní CLI."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/06-standard.md.filt
 #, no-wrap
 msgid "Standards Compliant"
@@ -699,14 +695,8 @@ msgstr "Chtěli byste se podílet na vývoji Gaphoru? (Pokud si myslíte, že je
 
 #. type: Plain text
 #: contribute.md.filt
-msgid "Our technical documentation is hosted on the wonderful service that is Read the Docs.  Not only does it contain details needed in order to make code contributions to Gaphor, but it outlines plenty of other ways in which you can contribute (including making updates to this website). Finally, it provides a guide to our processes and expectations for the various types of contribution you can make to Gaphor."
-msgstr ""
-"Naše technická dokumentace je umístěna na skvělé službě Read the Docs.  "
-"Nejenže obsahuje podrobnosti potřebné k tomu, abyste mohli do Gaphoru "
-"přispívat kódem, ale popisuje i spoustu dalších způsobů, jak můžete "
-"přispívat (včetně aktualizací této webové stránky). V neposlední řadě "
-"poskytuje průvodce našimi procesy a očekáváními pro různé typy příspěvků, "
-"které můžete do Gaphoru vložit."
+msgid "Our technical documentation is hosted on the wonderful service that is Read the Docs. Not only does it contain details needed in order to make code contributions to Gaphor, but it outlines plenty of other ways in which you can contribute (including making updates to this website). Finally, it provides a guide to our processes and expectations for the various types of contribution you can make to Gaphor."
+msgstr "Naše technická dokumentace je umístěna na skvělé službě Read the Docs. Nejenže obsahuje podrobnosti potřebné k tomu, abyste mohli do Gaphoru přispívat kódem, ale popisuje i spoustu dalších způsobů, jak můžete přispívat (včetně aktualizací této webové stránky). V neposlední řadě poskytuje průvodce našimi procesy a očekáváními pro různé typy příspěvků, které můžete do Gaphoru vložit."
 
 #. type: Plain text
 #: contribute.md.filt
@@ -814,9 +804,19 @@ msgstr ""
 msgid "Advanced topics"
 msgstr "Pokročilá témata"
 
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "Extend your models with stereotypes"
+msgstr ""
+
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "Writing a plugin"
+msgstr "Psaní zásuvného modulu"
+
 #. type: Plain text
 #: tutorials.md.filt
-msgid "- Extend your models with stereotypes - Writing a plugin - Technical and architectural documentation for contributors and plugin developers"
+msgid "- Technical and architectural documentation for contributors and plugin developers"
 msgstr "- Rozšiřování modelů pomocí stereotypů - Psaní zásuvného modulu - Technická a architektonická dokumentace pro přispěvatele a vývojáře zásuvných modulů"
 
 #. type: Title ##
@@ -844,24 +844,29 @@ msgstr "Arjan vystoupil na konferenci GUADEC 2021 s přednáškou na téma Velk�
 #: tutorials.md.filt
 #, no-wrap
 msgid "What other people say"
-msgstr "Co říkají ostatní"
+msgstr ""
 
 #. type: Plain text
 #: tutorials.md.filt
 msgid "There are some 10+ year old articles on Gaphor on the web. Some more recent articles are:"
 msgstr ""
-"Na webu je několik více než 10 let starých článků o Gaphoru. Některé novější "
-"články jsou:"
 
-#. type: Plain text
+#. type: Bullet: '- '
 #: tutorials.md.filt
-msgid "- Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on a Window 10.  - It's FOSS has a short write-up on Gaphor (~2.8-ish?).  - Ubuntu Pit has a nice article on Gaphor (~2.8-ish?)."
+msgid "Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on a Window 10."
 msgstr ""
-"- Webové stránky Metody a nástroje přezkoumaly verzi Gaphor 2.7.1 v prosinci "
-"2021 na Window 10.  - It's FOSS má krátký zápis o Gaphor (~2.8-ish?).  - "
-"Ubuntu Pit má pěkný článek o Gaphoru (~2.8-ish?)."
 
-#. type: YAML Front Matter: title
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "It's FOSS has a short write-up on Gaphor (~2.8-ish?)."
+msgstr ""
+
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "Ubuntu Pit has a nice article on Gaphor (~2.8-ish?)."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
 #: download.md.filt
 #, no-wrap
 msgid "Download Gaphor"
@@ -869,7 +874,7 @@ msgstr "Stáhnout Gaphor"
 
 #. type: Plain text
 #: download.md.filt
-msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all the required dependencies installed."
 msgstr "Existuje mnoho způsobů instalace systému Gaphor. Nejjednodušší je stáhnout si oficiální instalační program pro Windows nebo macOS. Pro Linux můžete Gaphor nainstalovat pomocí FlatHubu.  Můžete také použít vestavěný nástroj `pip` pro Python, pokud máte nainstalovány všechny potřebné závislosti."
 
 #. type: Plain text
@@ -894,17 +899,73 @@ msgstr "**Stránka nebyla nalezena :(**\n"
 msgid "The requested page could not be found."
 msgstr "Požadovanou stránku se nepodařilo najít."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: index.md.filt
 #, no-wrap
 msgid "Modeling for Everyone"
 msgstr "Modeling pro každého"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: blog.md.filt
 #, no-wrap
 msgid "Blog and News"
 msgstr "Blog a Zprávy"
+
+#, fuzzy, no-wrap
+#~| msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+#~ msgid ""
+#~ "There are many ways to install Gaphor.\n"
+#~ "The simplest is to download the official installer for Windows or macOS.\n"
+#~ "For Linux you can install Gaphor using FlatHub.\n"
+#~ "You can also use Python's built-in `pip` tool as long as you have all the\n"
+#~ "required dependencies installed.\n"
+#~ msgstr "Existuje mnoho způsobů instalace systému Gaphor. Nejjednodušší je stáhnout si oficiální instalační program pro Windows nebo macOS. Pro Linux můžete Gaphor nainstalovat pomocí FlatHubu.  Můžete také použít vestavěný nástroj `pip` pro Python, pokud máte nainstalovány všechny potřebné závislosti."
+
+#, fuzzy, no-wrap
+#~| msgid "Tutorials"
+#~ msgid "Tutorials\n"
+#~ msgstr "Tutoriály"
+
+#, fuzzy, no-wrap
+#~| msgid "Get in touch"
+#~ msgid "Get in touch\n"
+#~ msgstr "Spojte se s námi"
+
+#, fuzzy, no-wrap
+#~| msgid "Contribute"
+#~ msgid "Contribute\n"
+#~ msgstr "Přispět"
+
+#, fuzzy, no-wrap
+#~| msgid "Navigation"
+#~ msgid "Navigation\n"
+#~ msgstr "Navigace"
+
+#, fuzzy, no-wrap
+#~| msgid "Get started with Gaphor"
+#~ msgid "Get started with Gaphor\n"
+#~ msgstr "Začněte s aplikací Gaphor"
+
+#, fuzzy, no-wrap
+#~| msgid "Your First Model"
+#~ msgid "Your First Model\n"
+#~ msgstr "Váš první model"
+
+#, fuzzy, no-wrap
+#~| msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+#~ msgid ""
+#~ "There are many ways to install Gaphor. The simplest is to download the official\n"
+#~ "installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.\n"
+#~ "You can also use Python's built-in `pip` tool as long as you have all the\n"
+#~ "required dependencies installed.\n"
+#~ msgstr "Existuje mnoho způsobů instalace systému Gaphor. Nejjednodušší je stáhnout si oficiální instalační program pro Windows nebo macOS. Pro Linux můžete Gaphor nainstalovat pomocí FlatHubu.  Můžete také použít vestavěný nástroj `pip` pro Python, pokud máte nainstalovány všechny potřebné závislosti."
+
+#~ msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+#~ msgstr "Existuje mnoho způsobů instalace systému Gaphor. Nejjednodušší je stáhnout si oficiální instalační program pro Windows nebo macOS. Pro Linux můžete Gaphor nainstalovat pomocí FlatHubu.  Můžete také použít vestavěný nástroj `pip` pro Python, pokud máte nainstalovány všechny potřebné závislosti."
+
+#~| msgid "There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+#~ msgid "Love dark mode? We can do that too.  There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed.  Do you want to know what's going on with Gaphor? Read our blog!"
+#~ msgstr "Existuje mnoho způsobů instalace systému Gaphor.  Nejjednodušší je stáhnout si oficiální instalační program pro Windows nebo macOS.  Na Linux je možné nainstalovat Gaphor pomocí FlatHubu.  Můžete také použít vestavěný nástroj `pip` pro Python, pokud máte nainstalovány všechny potřebné závislosti."
 
 #~ msgid "Install Flatpak"
 #~ msgstr "Nainstalovat Flatpak"

--- a/po/site.es.po
+++ b/po/site.es.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-15 21:11-0300\n"
+"POT-Creation-Date: 2023-01-22 16:01-0500\n"
 "PO-Revision-Date: 2022-08-23 03:44+0000\n"
 "Last-Translator: Óscar Fernández Díaz <oscfdezdz@tuta.io>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/gaphor/gaphor-github-io/es/>\n"
@@ -29,13 +29,12 @@ msgstr "Abrir una incidencia en GitHub"
 
 #. type: Plain text
 #: _includes/footer.md.filt
-#, no-wrap
-msgid " Tech docs\n"
-msgstr " Documentación técnica\n"
+msgid "Tech docs"
+msgstr "Documentación técnica"
 
 #. type: Plain text
 #: _includes/footer.md.filt
-msgid "Copyright &copy; 2020-2022 Arjan Molenaar and Dan Yeaw."
+msgid "Copyright &copy; 2020-2023 Arjan Molenaar and Dan Yeaw."
 msgstr "Copyright &copy; 2020-2022 Arjan Molenaar y Dan Yeaw."
 
 #. type: Plain text
@@ -75,8 +74,8 @@ msgstr "¿Le gusta el modo oscuro? También podemos hacerlo."
 
 #. type: Plain text
 #: _includes/content.md.filt
-msgid "There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
-msgstr "Hay muchas maneras de instalar Gaphor.  La más sencilla es descargar el instalador oficial para Windows o macOS.  Para Linux puede instalar Gaphor usando FlatHub.  También puede usar la herramienta incorporada de Python `pip` siempre que tenga instaladas todas las dependencias necesarias."
+msgid "There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all the required dependencies installed."
+msgstr "Hay muchas maneras de instalar Gaphor. La más sencilla es descargar el instalador oficial para Windows o macOS. Para Linux puede instalar Gaphor usando FlatHub.  También puede utilizar la herramienta incorporada de Python `pip` siempre que tenga instaladas todas las dependencias necesarias."
 
 #. type: Plain text
 #: _includes/content.md.filt
@@ -113,7 +112,7 @@ msgstr "Saber más"
 msgid "About"
 msgstr "Acerca de"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt tutorials.md.filt
 #, no-wrap
 msgid "Tutorials"
@@ -124,19 +123,19 @@ msgstr "Tutoriales"
 msgid "Blog"
 msgstr "Blog"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt discuss.md.filt
 #, no-wrap
 msgid "Get in touch"
 msgstr "Póngase en contacto"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt contribute.md.filt
 #, no-wrap
 msgid "Contribute"
 msgstr "Contribuir"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/01-windows.md.filt
 #, no-wrap
 msgid "Windows"
@@ -159,7 +158,7 @@ msgstr "También se puede descargar una versión portable de Gaphor."
 msgid " Download portable version\n"
 msgstr " Descargar versión portable\n"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/02-macos.md.filt
 #, no-wrap
 msgid "macOS"
@@ -187,7 +186,7 @@ msgstr "Homebrew"
 msgid "Pour Gaphor from a homebrew cask:"
 msgstr "Vierta Gaphor de un barril de cerveza casera:"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/03-linux.md.filt
 #, no-wrap
 msgid "Linux"
@@ -242,7 +241,7 @@ msgstr "Arch Linux"
 msgid "Gaphor can be installed from an AUR package."
 msgstr "Gaphor puede instalarse desde un paquete AUR."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/04-python.md.filt
 #, no-wrap
 msgid "Python"
@@ -255,10 +254,10 @@ msgstr "Si tiene la última versión estable de Python instalada y las dependenc
 
 #. type: Plain text
 #: _platforms/04-python.md.filt
-msgid "If you don't have the latest stable version of Python and the Gaphor dependencies installed, follow the development environment installation instructions section, but do not clone the repository.  Optionally, create a virtual environment.  Then execute the following:"
+msgid "If you don't have the latest stable version of Python and the Gaphor dependencies installed, follow the development environment installation instructions section, but do not clone the repository. Optionally, create a virtual environment.  Then execute the following:"
 msgstr "Si no tiene instalada la última versión estable de Python y las dependencias de Gaphor, siga las instrucciones de instalación del entorno de desarrollo, pero no clone el repositorio.  Opcionalmente, cree un entorno virtual.  A continuación, ejecute lo siguiente:"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: tutorials/plugins.md.filt
 #, no-wrap
 msgid "Writing a Plugin"
@@ -308,7 +307,7 @@ msgstr "`lselect(query=None)` -> devuelve una lista"
 
 #. type: Plain text
 #: tutorials/plugins.md.filt
-msgid "`query` is a lambda function with the element as parameter. For example, to fetch all of the Class instances from the element factory:"
+msgid "`query` is a lambda function with the element as parameter. For example, to fetch all the Class instances from the element factory:"
 msgstr "`query` es una función lambda con el elemento como parámetro. Por ejemplo, para obtener todas las instancias de Class de la fábrica de elementos:"
 
 #. type: Title ##
@@ -348,7 +347,7 @@ msgstr "Ejemplo de plugin"
 msgid "An example Hello World plugin is hosted on GitHub."
 msgstr "Un ejemplo de plugin de Hola Mundo está alojado en GitHub."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: tutorials/report-bugs.md.filt
 #, no-wrap
 msgid "How to report a bug in Gaphor"
@@ -421,7 +420,7 @@ msgstr "Detalles técnicos como la versión de Gaphor que está usando, la versi
 
 #. type: Plain text
 #: tutorials/report-bugs.md.filt
-msgid "Use plain and simple language to describe the problem and, if helpful, break it down into steps so developers can easily recreate the issue. Please don't assume we'll understand what you were trying to achieve -- honestly, it's best if you try to imagine we (the developers) are a bunch of clever 5-year-olds.  Try to explain *everything* about the problem and don't assume we know what you mean. We won't mind!"
+msgid "Use plain and simple language to describe the problem and, if helpful, break it down into steps so developers can easily recreate the issue. Please don't assume we'll understand what you were trying to achieve -- honestly, it's best if you try to imagine we (the developers) are a bunch of clever 5-year-olds. Try to explain *everything* about the problem and don't assume we know what you mean.  We won't mind!"
 msgstr "Use un lenguaje claro y sencillo para describir el problema y, si es útil, divídalo en pasos para que los desarrolladores puedan recrear fácilmente el problema. Por favor, no dé por sentado que vamos a entender lo que intenta conseguir; sinceramente, es mejor que intente imaginar que nosotros (los desarrolladores) somos un grupo de niños inteligentes de 5 años.  Intente explicar *todo* el problema y no asuma que sabemos lo que quiere decir. ¡No nos importará!"
 
 #. type: Plain text
@@ -577,7 +576,7 @@ msgstr "Algunos elementos no son directamente visibles. La sección de la caja d
 
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
-msgid "Gaphor does not make any assumptions about which elements should be placed on a diagram. A diagram is a diagram. UML defines all different kinds of diagrams, such as Class diagrams, Component diagrams, Action diagrams, Sequence diagrams. But Gaphor does not place any restrictions."
+msgid "Gaphor does not make any assumptions about which elements should be placed on a diagram. A diagram is a diagram. UML defines all different kinds of diagrams, such as Class diagrams, Component diagrams, Action diagrams, Sequence diagrams.  But Gaphor does not place any restrictions."
 msgstr "Gaphor no hace ninguna suposición sobre los elementos que deben colocarse en un diagrama. Un diagrama es un diagrama. UML define todos los diferentes tipos de diagramas, tales como diagramas de clase, diagramas de componentes, diagramas de acción, diagramas de secuencia. Pero Gaphor no pone ninguna restricción."
 
 #. type: Title ##
@@ -588,7 +587,7 @@ msgstr "Crear diagramas nuevos"
 
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
-msgid "To create a new diagram, use the Navigation section. Select an element that can contain a diagram (a Package or Profile) and right-click. Select New diagram and a new diagram is created. As of Gaphor 1.1.0 a buttion is available in the header bar. Select a package and you'll notice the button is not grayed out and can be clicked, resulting in a new diagram being added to the model."
+msgid "To create a new diagram, use the Navigation section. Select an element that can contain a diagram (a Package or Profile) and right-click. Select New diagram and a new diagram is created. As of Gaphor 1.1.0 a buttion is available in the header bar. Select a package, and you'll notice the button is not grayed out and can be clicked, resulting in a new diagram being added to the model."
 msgstr "Para crear un diagrama nuevo, use la sección de Navegación. Seleccione un elemento que pueda contener un diagrama (un paquete o un perfil) y haga clic con el botón derecho del ratón. Seleccione Diagrama nuevo y se creará un nuevo diagrama. A partir de Gaphor 1.1.0 hay un botón disponible en la barra de encabezado. Seleccione un paquete y notará que el botón no está en gris y puede ser pulsado, lo que resulta en un nuevo diagrama que se añade al modelo."
 
 #. type: Title ##
@@ -604,7 +603,7 @@ msgstr "Los elementos de un diagrama pueden copiarse y pegarse (en el mismo diag
 
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
-msgid "This way you can easely create visual copies of the same (underlaying) model element."
+msgid "This way you can easily create visual copies of the same (underlying) model element."
 msgstr "De este modo, puede crear fácilmente copias visuales del mismo elemento del modelo (subyacente)."
 
 #. type: Title ##
@@ -623,7 +622,7 @@ msgstr "Añadir un elemento existente a un diagrama es sencillo: arrastre el ele
 msgid "Elements can also be dragged within the Navigation section. This way classes and packages can be rearranged for example."
 msgstr "Los elementos también se pueden arrastrar dentro de la sección de navegación. De esta manera se pueden reordenar, por ejemplo, las clases y los paquetes."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/01-platform.md.filt
 #, no-wrap
 msgid "Multi-platform"
@@ -634,7 +633,7 @@ msgstr "Multiplataforma"
 msgid "Gaphor works on all major platforms: Windows, Macos and Linux."
 msgstr "Gaphor funciona en las principales plataformas: Windows, Macos y Linux."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/02-opensource.md.filt
 #, no-wrap
 msgid "Open Source"
@@ -645,7 +644,7 @@ msgstr "Código abierto"
 msgid "No vendor lock-in: Gaphor written in Python and is 100% Open Source, available under a friendly Apache 2 license."
 msgstr "No hay bloqueo de proveedores: Gaphor está escrito en Python y es 100% de código abierto, disponible bajo una amigable licencia Apache 2."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/03-beginner-pro.md.filt
 #, no-wrap
 msgid "Beginner or Pro"
@@ -656,7 +655,7 @@ msgstr "Principiante o profesional"
 msgid "Whether you're a casual modeler documenting a project or a Model Driven Development expert, Gaphor has got you covered."
 msgstr "Tanto si es un modelador ocasional que documenta un proyecto como si es un experto en desarrollo dirigido por modelos, Gaphor le tiene cubierto."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/04-consistent.md.filt
 #, no-wrap
 msgid "Consistent"
@@ -667,7 +666,7 @@ msgstr "Consistente"
 msgid "UML is a graphical modeling language, so all information you put in the model is visible in the diagrams. For example, stereotypes are modeled in diagrams.  No hidden panels and property pages. Just diagrams!"
 msgstr "UML es un lenguaje de modelado gráfico, por lo que toda la información que se pone en el modelo es visible en los diagramas. Por ejemplo, los estereotipos se modelan en los diagramas.  No hay paneles ocultos ni páginas de propiedades. ¡Sólo diagramas!"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/05-extensible.md.filt
 #, no-wrap
 msgid "Extensible"
@@ -678,7 +677,7 @@ msgstr "Extensible"
 msgid "Gaphor is extensible. Plug-in a code generator or export your diagrams for documentation.  Create your own extensions and access them through the GUI or CLI."
 msgstr "Gaphor es extensible. Conecte un generador de código o exporte sus diagramas para la documentación.  Cree sus propias extensiones y acceda a ellas a través de la GUI o CLI."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/06-standard.md.filt
 #, no-wrap
 msgid "Standards Compliant"
@@ -696,9 +695,7 @@ msgstr "¿Le gustaría contribuir al desarrollo de Gaphor? (Si cree que esto es 
 
 #. type: Plain text
 #: contribute.md.filt
-#, fuzzy
-#| msgid "Our technical documentation is hosted on the wonderful service that is Read the Docs. Not only does it contain details needed in order to make code contributions to Gaphor, but it outlines plenty of other ways in which you can contribute (including making updates to this website). Finally, it provides a guide to our processes and expectations for the various types of contribution you can make to Gaphor."
-msgid "Our technical documentation is hosted on the wonderful service that is Read the Docs.  Not only does it contain details needed in order to make code contributions to Gaphor, but it outlines plenty of other ways in which you can contribute (including making updates to this website). Finally, it provides a guide to our processes and expectations for the various types of contribution you can make to Gaphor."
+msgid "Our technical documentation is hosted on the wonderful service that is Read the Docs. Not only does it contain details needed in order to make code contributions to Gaphor, but it outlines plenty of other ways in which you can contribute (including making updates to this website). Finally, it provides a guide to our processes and expectations for the various types of contribution you can make to Gaphor."
 msgstr "Nuestra documentación técnica está alojada en el maravilloso servicio Read the Docs. No sólo contiene los detalles necesarios para hacer contribuciones de código a Gaphor, sino que describe muchas otras formas en las que puede contribuir (incluyendo hacer actualizaciones a este sitio web). Por último, proporciona una guía de nuestros procesos y expectativas para los distintos tipos de contribución que puede hacer a Gaphor."
 
 #. type: Plain text
@@ -807,9 +804,19 @@ msgstr ""
 msgid "Advanced topics"
 msgstr "Temas avanzados"
 
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "Extend your models with stereotypes"
+msgstr ""
+
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "Writing a plugin"
+msgstr "Escribir un plugin"
+
 #. type: Plain text
 #: tutorials.md.filt
-msgid "- Extend your models with stereotypes - Writing a plugin - Technical and architectural documentation for contributors and plugin developers"
+msgid "- Technical and architectural documentation for contributors and plugin developers"
 msgstr "- Extender sus modelos con estereotipos - Escribir un plugin - Documentación técnica y arquitectónica para colaboradores y desarrolladores de plugins"
 
 #. type: Title ##
@@ -844,12 +851,22 @@ msgstr ""
 msgid "There are some 10+ year old articles on Gaphor on the web. Some more recent articles are:"
 msgstr ""
 
-#. type: Plain text
+#. type: Bullet: '- '
 #: tutorials.md.filt
-msgid "- Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on a Window 10.  - It's FOSS has a short write-up on Gaphor (~2.8-ish?).  - Ubuntu Pit has a nice article on Gaphor (~2.8-ish?)."
+msgid "Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on a Window 10."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "It's FOSS has a short write-up on Gaphor (~2.8-ish?)."
+msgstr ""
+
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "Ubuntu Pit has a nice article on Gaphor (~2.8-ish?)."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
 #: download.md.filt
 #, no-wrap
 msgid "Download Gaphor"
@@ -857,7 +874,7 @@ msgstr "Descargar Gaphor"
 
 #. type: Plain text
 #: download.md.filt
-msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all the required dependencies installed."
 msgstr "Hay muchas maneras de instalar Gaphor. La más sencilla es descargar el instalador oficial para Windows o macOS. Para Linux puede instalar Gaphor usando FlatHub.  También puede utilizar la herramienta incorporada de Python `pip` siempre que tenga instaladas todas las dependencias necesarias."
 
 #. type: Plain text
@@ -882,17 +899,73 @@ msgstr "**Página no encontrada :(**\n"
 msgid "The requested page could not be found."
 msgstr "No se ha podido encontrar la página solicitada."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: index.md.filt
 #, no-wrap
 msgid "Modeling for Everyone"
 msgstr "Modelado para todos"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: blog.md.filt
 #, no-wrap
 msgid "Blog and News"
 msgstr "Blog y noticias"
+
+#, fuzzy, no-wrap
+#~| msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+#~ msgid ""
+#~ "There are many ways to install Gaphor.\n"
+#~ "The simplest is to download the official installer for Windows or macOS.\n"
+#~ "For Linux you can install Gaphor using FlatHub.\n"
+#~ "You can also use Python's built-in `pip` tool as long as you have all the\n"
+#~ "required dependencies installed.\n"
+#~ msgstr "Hay muchas maneras de instalar Gaphor. La más sencilla es descargar el instalador oficial para Windows o macOS. Para Linux puede instalar Gaphor usando FlatHub.  También puede utilizar la herramienta incorporada de Python `pip` siempre que tenga instaladas todas las dependencias necesarias."
+
+#, fuzzy, no-wrap
+#~| msgid "Tutorials"
+#~ msgid "Tutorials\n"
+#~ msgstr "Tutoriales"
+
+#, fuzzy, no-wrap
+#~| msgid "Get in touch"
+#~ msgid "Get in touch\n"
+#~ msgstr "Póngase en contacto"
+
+#, fuzzy, no-wrap
+#~| msgid "Contribute"
+#~ msgid "Contribute\n"
+#~ msgstr "Contribuir"
+
+#, fuzzy, no-wrap
+#~| msgid "Navigation"
+#~ msgid "Navigation\n"
+#~ msgstr "Navegación"
+
+#, fuzzy, no-wrap
+#~| msgid "Get started with Gaphor"
+#~ msgid "Get started with Gaphor\n"
+#~ msgstr "Empezar con Gaphor"
+
+#, fuzzy, no-wrap
+#~| msgid "Your First Model"
+#~ msgid "Your First Model\n"
+#~ msgstr "Su primer modelo"
+
+#, fuzzy, no-wrap
+#~| msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+#~ msgid ""
+#~ "There are many ways to install Gaphor. The simplest is to download the official\n"
+#~ "installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.\n"
+#~ "You can also use Python's built-in `pip` tool as long as you have all the\n"
+#~ "required dependencies installed.\n"
+#~ msgstr "Hay muchas maneras de instalar Gaphor. La más sencilla es descargar el instalador oficial para Windows o macOS. Para Linux puede instalar Gaphor usando FlatHub.  También puede utilizar la herramienta incorporada de Python `pip` siempre que tenga instaladas todas las dependencias necesarias."
+
+#~ msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+#~ msgstr "Hay muchas maneras de instalar Gaphor. La más sencilla es descargar el instalador oficial para Windows o macOS. Para Linux puede instalar Gaphor usando FlatHub.  También puede utilizar la herramienta incorporada de Python `pip` siempre que tenga instaladas todas las dependencias necesarias."
+
+#~| msgid "There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+#~ msgid "Love dark mode? We can do that too.  There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed.  Do you want to know what's going on with Gaphor? Read our blog!"
+#~ msgstr "Hay muchas maneras de instalar Gaphor.  La más sencilla es descargar el instalador oficial para Windows o macOS.  Para Linux puede instalar Gaphor usando FlatHub.  También puede usar la herramienta incorporada de Python `pip` siempre que tenga instaladas todas las dependencias necesarias."
 
 #~ msgid "Install Flatpak"
 #~ msgstr "Instalar Flatpak"

--- a/po/site.hr.po
+++ b/po/site.hr.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-15 21:11-0300\n"
+"POT-Creation-Date: 2023-01-22 16:01-0500\n"
 "PO-Revision-Date: 2022-10-21 04:02+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/gaphor/gaphor-github-io/hr/>\n"
@@ -29,13 +29,12 @@ msgstr "Prijavi problem na GitHubu"
 
 #. type: Plain text
 #: _includes/footer.md.filt
-#, no-wrap
-msgid " Tech docs\n"
-msgstr " Tehnička dokumentacija\n"
+msgid "Tech docs"
+msgstr "Tehnička dokumentacija"
 
 #. type: Plain text
 #: _includes/footer.md.filt
-msgid "Copyright &copy; 2020-2022 Arjan Molenaar and Dan Yeaw."
+msgid "Copyright &copy; 2020-2023 Arjan Molenaar and Dan Yeaw."
 msgstr "Autorska prava &copy; 2020. – 2022. Arjan Molenaar i Dan Yeaw."
 
 #. type: Plain text
@@ -75,7 +74,7 @@ msgstr "Voliš tamni modus? Omogućujemo i to."
 
 #. type: Plain text
 #: _includes/content.md.filt
-msgid "There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+msgid "There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all the required dependencies installed."
 msgstr "Postoji mnogo načina za instaliranje Gaphora. Najjednostavnije je preuzeti službeni instalacijski program za Windows ili macOS. Za Linux se Gaphor može instalirati koristeći FlatHub. Također je moguće koristiti Pythonov ugrađeni `pip` alat ukoliko su sve potrebne ovisnosti instalirane."
 
 #. type: Plain text
@@ -113,7 +112,7 @@ msgstr "Saznaj više"
 msgid "About"
 msgstr "Informacije"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt tutorials.md.filt
 #, no-wrap
 msgid "Tutorials"
@@ -124,19 +123,19 @@ msgstr "Vježbe"
 msgid "Blog"
 msgstr "Blog"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt discuss.md.filt
 #, no-wrap
 msgid "Get in touch"
 msgstr "Kontaktiraj zajednicu"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt contribute.md.filt
 #, no-wrap
 msgid "Contribute"
 msgstr "Doprinesi"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/01-windows.md.filt
 #, no-wrap
 msgid "Windows"
@@ -159,7 +158,7 @@ msgstr "Alternativno možeš preuzeti prenosivu verziju Gaphora."
 msgid " Download portable version\n"
 msgstr " Preuzmi prenosivu verziju\n"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/02-macos.md.filt
 #, no-wrap
 msgid "macOS"
@@ -187,7 +186,7 @@ msgstr "Homebrew"
 msgid "Pour Gaphor from a homebrew cask:"
 msgstr "Instaliraj Gaphor iz jednog homebrew cask:"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/03-linux.md.filt
 #, no-wrap
 msgid "Linux"
@@ -242,7 +241,7 @@ msgstr "Arch Linux"
 msgid "Gaphor can be installed from an AUR package."
 msgstr "Gaphor se može instalirati iz jednog AUR paketa."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/04-python.md.filt
 #, no-wrap
 msgid "Python"
@@ -255,10 +254,10 @@ msgstr "Ako imaš instaliranu najnoviju stabilnu verziju Pythona i ovisnosti za 
 
 #. type: Plain text
 #: _platforms/04-python.md.filt
-msgid "If you don't have the latest stable version of Python and the Gaphor dependencies installed, follow the development environment installation instructions section, but do not clone the repository.  Optionally, create a virtual environment.  Then execute the following:"
+msgid "If you don't have the latest stable version of Python and the Gaphor dependencies installed, follow the development environment installation instructions section, but do not clone the repository. Optionally, create a virtual environment.  Then execute the following:"
 msgstr "Ako nemaš instaliranu najnoviju stabilnu verziju Pythona i ovisnosti za Gaphor, slijedi upute u odjeljku za instalaciju razvojnog okruženja, ali nemoj izraditi klon repozitorija. Opcionalno, stvori virtualno okruženje. Zatim izvrši sljedeće:"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: tutorials/plugins.md.filt
 #, no-wrap
 msgid "Writing a Plugin"
@@ -308,7 +307,7 @@ msgstr "`lselect(query=None)` -> vraća popis"
 
 #. type: Plain text
 #: tutorials/plugins.md.filt
-msgid "`query` is a lambda function with the element as parameter. For example, to fetch all of the Class instances from the element factory:"
+msgid "`query` is a lambda function with the element as parameter. For example, to fetch all the Class instances from the element factory:"
 msgstr "`query` je lambda funkcija s elementom kao parametrom. Na primjer, za dohvaćanje svih instanci klasa iz tvornice elemenata:"
 
 #. type: Title ##
@@ -348,7 +347,7 @@ msgstr "Primjer dodatka"
 msgid "An example Hello World plugin is hosted on GitHub."
 msgstr "Primjer dodatka „Hello World” nalazi se na GitHubu."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: tutorials/report-bugs.md.filt
 #, no-wrap
 msgid "How to report a bug in Gaphor"
@@ -421,7 +420,7 @@ msgstr "Tehničke detalje kao što su verzija korištenog Gaphora, verzija OS-a 
 
 #. type: Plain text
 #: tutorials/report-bugs.md.filt
-msgid "Use plain and simple language to describe the problem and, if helpful, break it down into steps so developers can easily recreate the issue. Please don't assume we'll understand what you were trying to achieve -- honestly, it's best if you try to imagine we (the developers) are a bunch of clever 5-year-olds.  Try to explain *everything* about the problem and don't assume we know what you mean. We won't mind!"
+msgid "Use plain and simple language to describe the problem and, if helpful, break it down into steps so developers can easily recreate the issue. Please don't assume we'll understand what you were trying to achieve -- honestly, it's best if you try to imagine we (the developers) are a bunch of clever 5-year-olds. Try to explain *everything* about the problem and don't assume we know what you mean.  We won't mind!"
 msgstr "Koristi jednostavan jezik za opisivanje problema i, ako treba, navedi radnje prije pojavljivanja problema korak po korak, kako bi programeri mogli reproducirati problem. Nemoj pretpostavljati da ćemo razumjeti što si pokušavao/la postići – iskreno rečeno, najbolje je ako pokušaš zamisliti da smo mi (programeri) gomila pametnih petogodišnjaka. Pokušaj objasniti *sve* o problemu i nemoj pretpostavljati da znamo što misliš. Nećemo imati ništa protiv!"
 
 #. type: Plain text
@@ -577,7 +576,7 @@ msgstr "Neki elementi nisu izravno vidljivi. Odjeljak u kutiji alata je skloplje
 
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
-msgid "Gaphor does not make any assumptions about which elements should be placed on a diagram. A diagram is a diagram. UML defines all different kinds of diagrams, such as Class diagrams, Component diagrams, Action diagrams, Sequence diagrams. But Gaphor does not place any restrictions."
+msgid "Gaphor does not make any assumptions about which elements should be placed on a diagram. A diagram is a diagram. UML defines all different kinds of diagrams, such as Class diagrams, Component diagrams, Action diagrams, Sequence diagrams.  But Gaphor does not place any restrictions."
 msgstr "Gaphor ne pretpostavlja koji se elementi trebaju postaviti na dijagram. Dijagram je dijagram. UML definira sve različite vrste dijagrama, kao što su dijagrami klasa, dijagrami komponenti, dijagrami radnji, dijagrami sekvenci. Ali Gaphor ne postavlja nikakva ograničenja."
 
 #. type: Title ##
@@ -588,7 +587,7 @@ msgstr "Stvaranje novih dijagrama"
 
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
-msgid "To create a new diagram, use the Navigation section. Select an element that can contain a diagram (a Package or Profile) and right-click. Select New diagram and a new diagram is created. As of Gaphor 1.1.0 a buttion is available in the header bar. Select a package and you'll notice the button is not grayed out and can be clicked, resulting in a new diagram being added to the model."
+msgid "To create a new diagram, use the Navigation section. Select an element that can contain a diagram (a Package or Profile) and right-click. Select New diagram and a new diagram is created. As of Gaphor 1.1.0 a buttion is available in the header bar. Select a package, and you'll notice the button is not grayed out and can be clicked, resulting in a new diagram being added to the model."
 msgstr "Za stvaranje novog dijagrama koristi odjeljak „Navigacija”. Odaberi element koji može sadržavati dijagram (paket ili profil) i pritisni za desnom tipkom miša. Odaberi „Novi dijagram” i stvorit će se novi dijagram. Uvođenjem Gaphora verzije 1.1.0, postoji gumb u traci zaglavlja. Odaberi paket i primijetit ćeš da gumb nije neaktivan i da ga se može pritisnuti. Pritiskom gumba modelu se dodaje novi dijagram."
 
 #. type: Title ##
@@ -604,7 +603,7 @@ msgstr "Elementi u dijagramu mogu se kopirati i umetnuti (u istom ili jednom dru
 
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
-msgid "This way you can easely create visual copies of the same (underlaying) model element."
+msgid "This way you can easily create visual copies of the same (underlying) model element."
 msgstr "Na taj način možeš jednostavno stvoriti virtualne kopije istog (podmetnutog) elementa modela."
 
 #. type: Title ##
@@ -623,7 +622,7 @@ msgstr "Dodavanje postojećeg elementa dijagramu je jednostavno: povuci element 
 msgid "Elements can also be dragged within the Navigation section. This way classes and packages can be rearranged for example."
 msgstr "Elementi se također mogu povlačiti unutar odjeljka „Navigacija”. Na taj se način na primjer mogu prerasporediti klase i paketi."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/01-platform.md.filt
 #, no-wrap
 msgid "Multi-platform"
@@ -634,7 +633,7 @@ msgstr "Višeplatformski"
 msgid "Gaphor works on all major platforms: Windows, Macos and Linux."
 msgstr "Gaphor radi na svim glavnim platformama: Windows, Macos i Linux."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/02-opensource.md.filt
 #, no-wrap
 msgid "Open Source"
@@ -645,7 +644,7 @@ msgstr "Otvoreni kod"
 msgid "No vendor lock-in: Gaphor written in Python and is 100% Open Source, available under a friendly Apache 2 license."
 msgstr "Bez ograničenja od strane proizvođača: Gaphor je napisan u Pythonu, 100 % otvorenog koda, dostupan pod licencom Apache 2."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/03-beginner-pro.md.filt
 #, no-wrap
 msgid "Beginner or Pro"
@@ -656,7 +655,7 @@ msgstr "Za početnike ili profesionalace"
 msgid "Whether you're a casual modeler documenting a project or a Model Driven Development expert, Gaphor has got you covered."
 msgstr "Svejedno jesi li običan modelar koji dokumentira projekte ili stručnjak za softverski razvoj modela, Gaphor sadrži sve što trebaš."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/04-consistent.md.filt
 #, no-wrap
 msgid "Consistent"
@@ -667,7 +666,7 @@ msgstr "Dosljedan"
 msgid "UML is a graphical modeling language, so all information you put in the model is visible in the diagrams. For example, stereotypes are modeled in diagrams.  No hidden panels and property pages. Just diagrams!"
 msgstr "UML je jezik za grafičko modeliranje, tako da su sve u model unesene informacije vidljive u dijagramima. Na primjer, stereotipi se modeliraju u dijagramima. Nema skrivenih ploča i stranica sa svojstvima. Samo dijagrami!"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/05-extensible.md.filt
 #, no-wrap
 msgid "Extensible"
@@ -678,7 +677,7 @@ msgstr "Proširiv"
 msgid "Gaphor is extensible. Plug-in a code generator or export your diagrams for documentation.  Create your own extensions and access them through the GUI or CLI."
 msgstr "Gaphor je proširiv. Dodaj generator koda ili izvezi dijagrame za dokumentaciju. Stvori vlastita proširenja i pristupi im putem grafičkog sučelja ili putem naredbenog retka."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/06-standard.md.filt
 #, no-wrap
 msgid "Standards Compliant"
@@ -696,9 +695,7 @@ msgstr "Želiš doprinijeti razvoju Gaphora? Ako misliš da je ovo samo za iskus
 
 #. type: Plain text
 #: contribute.md.filt
-#, fuzzy
-#| msgid "Our technical documentation is hosted on the wonderful service that is Read the Docs. Not only does it contain details needed in order to make code contributions to Gaphor, but it outlines plenty of other ways in which you can contribute (including making updates to this website). Finally, it provides a guide to our processes and expectations for the various types of contribution you can make to Gaphor."
-msgid "Our technical documentation is hosted on the wonderful service that is Read the Docs.  Not only does it contain details needed in order to make code contributions to Gaphor, but it outlines plenty of other ways in which you can contribute (including making updates to this website). Finally, it provides a guide to our processes and expectations for the various types of contribution you can make to Gaphor."
+msgid "Our technical documentation is hosted on the wonderful service that is Read the Docs. Not only does it contain details needed in order to make code contributions to Gaphor, but it outlines plenty of other ways in which you can contribute (including making updates to this website). Finally, it provides a guide to our processes and expectations for the various types of contribution you can make to Gaphor."
 msgstr "Naša se tehnička dokumentacija čuva na usluzi „Read the Docs”. Ne samo da sadrži potrebne pojedinosti za doprinošenje kodu Gaphora, već opisuje i mnoge druge načine za doprinošenje (uključujući aktualiziranje ove web-stranice). Na kraju krajeva, pruža vodič za naše procese i očekivanja za različite vrste doprinosa Gaphoru."
 
 #. type: Plain text
@@ -807,9 +804,19 @@ msgstr ""
 msgid "Advanced topics"
 msgstr "Napredne teme"
 
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "Extend your models with stereotypes"
+msgstr ""
+
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "Writing a plugin"
+msgstr "Pisanje dodatka"
+
 #. type: Plain text
 #: tutorials.md.filt
-msgid "- Extend your models with stereotypes - Writing a plugin - Technical and architectural documentation for contributors and plugin developers"
+msgid "- Technical and architectural documentation for contributors and plugin developers"
 msgstr "- Proširi svoje modele sa stereotipima - Pisanje dodatka - Tehnička i arhitektonska dokumentacija za doprinositelje i programere dodataka"
 
 #. type: Title ##
@@ -844,12 +851,22 @@ msgstr ""
 msgid "There are some 10+ year old articles on Gaphor on the web. Some more recent articles are:"
 msgstr ""
 
-#. type: Plain text
+#. type: Bullet: '- '
 #: tutorials.md.filt
-msgid "- Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on a Window 10.  - It's FOSS has a short write-up on Gaphor (~2.8-ish?).  - Ubuntu Pit has a nice article on Gaphor (~2.8-ish?)."
+msgid "Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on a Window 10."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "It's FOSS has a short write-up on Gaphor (~2.8-ish?)."
+msgstr ""
+
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "Ubuntu Pit has a nice article on Gaphor (~2.8-ish?)."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
 #: download.md.filt
 #, no-wrap
 msgid "Download Gaphor"
@@ -857,7 +874,7 @@ msgstr "Preuzmi Gaphor"
 
 #. type: Plain text
 #: download.md.filt
-msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all the required dependencies installed."
 msgstr "Postoji mnogo načina za instaliranje Gaphora. Najjednostavnije je preuzeti službeni instalacijski program za Windows ili macOS. Za Linux se Gaphor može instalirati koristeći FlatHub. Također je moguće koristiti Pythonov ugrađeni `pip` alat ukoliko su sve potrebne ovisnosti instalirane."
 
 #. type: Plain text
@@ -882,17 +899,73 @@ msgstr "**Stranica nije pronađena :(**\n"
 msgid "The requested page could not be found."
 msgstr "Zatražena stranica nije pronađena."
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: index.md.filt
 #, no-wrap
 msgid "Modeling for Everyone"
 msgstr "Modeliranje za svakoga"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: blog.md.filt
 #, no-wrap
 msgid "Blog and News"
 msgstr "Blog i Novosti"
+
+#, fuzzy, no-wrap
+#~| msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+#~ msgid ""
+#~ "There are many ways to install Gaphor.\n"
+#~ "The simplest is to download the official installer for Windows or macOS.\n"
+#~ "For Linux you can install Gaphor using FlatHub.\n"
+#~ "You can also use Python's built-in `pip` tool as long as you have all the\n"
+#~ "required dependencies installed.\n"
+#~ msgstr "Postoji mnogo načina za instaliranje Gaphora. Najjednostavnije je preuzeti službeni instalacijski program za Windows ili macOS. Za Linux se Gaphor može instalirati koristeći FlatHub. Također je moguće koristiti Pythonov ugrađeni `pip` alat ukoliko su sve potrebne ovisnosti instalirane."
+
+#, fuzzy, no-wrap
+#~| msgid "Tutorials"
+#~ msgid "Tutorials\n"
+#~ msgstr "Vježbe"
+
+#, fuzzy, no-wrap
+#~| msgid "Get in touch"
+#~ msgid "Get in touch\n"
+#~ msgstr "Kontaktiraj zajednicu"
+
+#, fuzzy, no-wrap
+#~| msgid "Contribute"
+#~ msgid "Contribute\n"
+#~ msgstr "Doprinesi"
+
+#, fuzzy, no-wrap
+#~| msgid "Navigation"
+#~ msgid "Navigation\n"
+#~ msgstr "Navigacija"
+
+#, fuzzy, no-wrap
+#~| msgid "Get started with Gaphor"
+#~ msgid "Get started with Gaphor\n"
+#~ msgstr "Počni raditi s Gaphorom"
+
+#, fuzzy, no-wrap
+#~| msgid "Your First Model"
+#~ msgid "Your First Model\n"
+#~ msgstr "Tvoj prvi model"
+
+#, fuzzy, no-wrap
+#~| msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+#~ msgid ""
+#~ "There are many ways to install Gaphor. The simplest is to download the official\n"
+#~ "installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.\n"
+#~ "You can also use Python's built-in `pip` tool as long as you have all the\n"
+#~ "required dependencies installed.\n"
+#~ msgstr "Postoji mnogo načina za instaliranje Gaphora. Najjednostavnije je preuzeti službeni instalacijski program za Windows ili macOS. Za Linux se Gaphor može instalirati koristeći FlatHub. Također je moguće koristiti Pythonov ugrađeni `pip` alat ukoliko su sve potrebne ovisnosti instalirane."
+
+#~ msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+#~ msgstr "Postoji mnogo načina za instaliranje Gaphora. Najjednostavnije je preuzeti službeni instalacijski program za Windows ili macOS. Za Linux se Gaphor može instalirati koristeći FlatHub. Također je moguće koristiti Pythonov ugrađeni `pip` alat ukoliko su sve potrebne ovisnosti instalirane."
+
+#~| msgid "There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+#~ msgid "Love dark mode? We can do that too.  There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed.  Do you want to know what's going on with Gaphor? Read our blog!"
+#~ msgstr "Postoji mnogo načina za instaliranje Gaphora. Najjednostavnije je preuzeti službeni instalacijski program za Windows ili macOS. Za Linux se Gaphor može instalirati koristeći FlatHub. Također je moguće koristiti Pythonov ugrađeni `pip` alat ukoliko su sve potrebne ovisnosti instalirane."
 
 #~ msgid "Install Flatpak"
 #~ msgstr "Instaliraj Flatpak"

--- a/po/site.hu.po
+++ b/po/site.hu.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-15 21:11-0300\n"
+"POT-Creation-Date: 2023-01-22 16:01-0500\n"
 "PO-Revision-Date: 2022-10-21 04:02+0000\n"
 "Last-Translator: ovari <ovari123@zoho.com>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/gaphor/gaphor-github-io/hu/>\n"
@@ -29,19 +29,18 @@ msgstr "Probléma megnyitása a GitHubon"
 
 #. type: Plain text
 #: _includes/footer.md.filt
-#, no-wrap
-msgid " Tech docs\n"
-msgstr " Műszaki dokumentumok\n"
+msgid "Tech docs"
+msgstr ""
 
 #. type: Plain text
 #: _includes/footer.md.filt
-msgid "Copyright &copy; 2020-2022 Arjan Molenaar and Dan Yeaw."
+msgid "Copyright &copy; 2020-2023 Arjan Molenaar and Dan Yeaw."
 msgstr "Szerzői jog &copy; 2020-2022 Molenaar Arjan és Yeaw Dániel."
 
 #. type: Plain text
 #: _includes/footer.md.filt
 msgid "Theme"
-msgstr "Téma"
+msgstr ""
 
 #. type: Plain text
 #: _includes/content.md.filt
@@ -75,7 +74,7 @@ msgstr ""
 
 #. type: Plain text
 #: _includes/content.md.filt
-msgid "There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+msgid "There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all the required dependencies installed."
 msgstr ""
 
 #. type: Plain text
@@ -95,8 +94,10 @@ msgstr "Napló megtekintése"
 
 #. type: Plain text
 #: _includes/content.md.filt
+#, fuzzy
+#| msgid "Learn more"
 msgid "Read more"
-msgstr ""
+msgstr "További tájékoztatás"
 
 #. type: Plain text
 #: _includes/content.md.filt
@@ -113,7 +114,7 @@ msgstr "További tájékoztatás"
 msgid "About"
 msgstr "Rólunk"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt tutorials.md.filt
 #, no-wrap
 msgid "Tutorials"
@@ -124,23 +125,23 @@ msgstr "Oktatóanyagok"
 msgid "Blog"
 msgstr "Napló"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt discuss.md.filt
 #, no-wrap
 msgid "Get in touch"
 msgstr "Kapcsolatfelvétel"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt contribute.md.filt
 #, no-wrap
 msgid "Contribute"
 msgstr "Közreműködés"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/01-windows.md.filt
 #, no-wrap
 msgid "Windows"
-msgstr ""
+msgstr "Windows"
 
 #. type: Plain text
 #: _platforms/01-windows.md.filt
@@ -159,11 +160,11 @@ msgstr ""
 msgid " Download portable version\n"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/02-macos.md.filt
 #, no-wrap
 msgid "macOS"
-msgstr ""
+msgstr "macOS"
 
 #. type: Plain text
 #: _platforms/02-macos.md.filt
@@ -180,24 +181,24 @@ msgstr ""
 #: _platforms/02-macos.md.filt
 #, no-wrap
 msgid "Homebrew"
-msgstr ""
+msgstr "Homebrew"
 
 #. type: Plain text
 #: _platforms/02-macos.md.filt
 msgid "Pour Gaphor from a homebrew cask:"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/03-linux.md.filt
 #, no-wrap
 msgid "Linux"
-msgstr ""
+msgstr "Linux"
 
 #. type: Title ###
 #: _platforms/03-linux.md.filt
 #, no-wrap
 msgid "Flatpak"
-msgstr ""
+msgstr "Flatpak"
 
 #. type: Plain text
 #: _platforms/03-linux.md.filt
@@ -242,7 +243,7 @@ msgstr ""
 msgid "Gaphor can be installed from an AUR package."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/04-python.md.filt
 #, no-wrap
 msgid "Python"
@@ -255,10 +256,10 @@ msgstr ""
 
 #. type: Plain text
 #: _platforms/04-python.md.filt
-msgid "If you don't have the latest stable version of Python and the Gaphor dependencies installed, follow the development environment installation instructions section, but do not clone the repository.  Optionally, create a virtual environment.  Then execute the following:"
+msgid "If you don't have the latest stable version of Python and the Gaphor dependencies installed, follow the development environment installation instructions section, but do not clone the repository. Optionally, create a virtual environment.  Then execute the following:"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: tutorials/plugins.md.filt
 #, no-wrap
 msgid "Writing a Plugin"
@@ -308,7 +309,7 @@ msgstr ""
 
 #. type: Plain text
 #: tutorials/plugins.md.filt
-msgid "`query` is a lambda function with the element as parameter. For example, to fetch all of the Class instances from the element factory:"
+msgid "`query` is a lambda function with the element as parameter. For example, to fetch all the Class instances from the element factory:"
 msgstr ""
 
 #. type: Title ##
@@ -348,7 +349,7 @@ msgstr ""
 msgid "An example Hello World plugin is hosted on GitHub."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: tutorials/report-bugs.md.filt
 #, no-wrap
 msgid "How to report a bug in Gaphor"
@@ -421,7 +422,7 @@ msgstr ""
 
 #. type: Plain text
 #: tutorials/report-bugs.md.filt
-msgid "Use plain and simple language to describe the problem and, if helpful, break it down into steps so developers can easily recreate the issue. Please don't assume we'll understand what you were trying to achieve -- honestly, it's best if you try to imagine we (the developers) are a bunch of clever 5-year-olds.  Try to explain *everything* about the problem and don't assume we know what you mean. We won't mind!"
+msgid "Use plain and simple language to describe the problem and, if helpful, break it down into steps so developers can easily recreate the issue. Please don't assume we'll understand what you were trying to achieve -- honestly, it's best if you try to imagine we (the developers) are a bunch of clever 5-year-olds. Try to explain *everything* about the problem and don't assume we know what you mean.  We won't mind!"
 msgstr ""
 
 #. type: Plain text
@@ -577,7 +578,7 @@ msgstr ""
 
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
-msgid "Gaphor does not make any assumptions about which elements should be placed on a diagram. A diagram is a diagram. UML defines all different kinds of diagrams, such as Class diagrams, Component diagrams, Action diagrams, Sequence diagrams. But Gaphor does not place any restrictions."
+msgid "Gaphor does not make any assumptions about which elements should be placed on a diagram. A diagram is a diagram. UML defines all different kinds of diagrams, such as Class diagrams, Component diagrams, Action diagrams, Sequence diagrams.  But Gaphor does not place any restrictions."
 msgstr ""
 
 #. type: Title ##
@@ -588,7 +589,7 @@ msgstr ""
 
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
-msgid "To create a new diagram, use the Navigation section. Select an element that can contain a diagram (a Package or Profile) and right-click. Select New diagram and a new diagram is created. As of Gaphor 1.1.0 a buttion is available in the header bar. Select a package and you'll notice the button is not grayed out and can be clicked, resulting in a new diagram being added to the model."
+msgid "To create a new diagram, use the Navigation section. Select an element that can contain a diagram (a Package or Profile) and right-click. Select New diagram and a new diagram is created. As of Gaphor 1.1.0 a buttion is available in the header bar. Select a package, and you'll notice the button is not grayed out and can be clicked, resulting in a new diagram being added to the model."
 msgstr ""
 
 #. type: Title ##
@@ -604,7 +605,7 @@ msgstr ""
 
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
-msgid "This way you can easely create visual copies of the same (underlaying) model element."
+msgid "This way you can easily create visual copies of the same (underlying) model element."
 msgstr ""
 
 #. type: Title ##
@@ -623,7 +624,7 @@ msgstr ""
 msgid "Elements can also be dragged within the Navigation section. This way classes and packages can be rearranged for example."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/01-platform.md.filt
 #, no-wrap
 msgid "Multi-platform"
@@ -634,7 +635,7 @@ msgstr "Többplatformos"
 msgid "Gaphor works on all major platforms: Windows, Macos and Linux."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/02-opensource.md.filt
 #, no-wrap
 msgid "Open Source"
@@ -645,7 +646,7 @@ msgstr "Nyílt forráskódú"
 msgid "No vendor lock-in: Gaphor written in Python and is 100% Open Source, available under a friendly Apache 2 license."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/03-beginner-pro.md.filt
 #, no-wrap
 msgid "Beginner or Pro"
@@ -656,7 +657,7 @@ msgstr "Kezdő vagy szakmai"
 msgid "Whether you're a casual modeler documenting a project or a Model Driven Development expert, Gaphor has got you covered."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/04-consistent.md.filt
 #, no-wrap
 msgid "Consistent"
@@ -667,7 +668,7 @@ msgstr "Egységes"
 msgid "UML is a graphical modeling language, so all information you put in the model is visible in the diagrams. For example, stereotypes are modeled in diagrams.  No hidden panels and property pages. Just diagrams!"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/05-extensible.md.filt
 #, no-wrap
 msgid "Extensible"
@@ -678,7 +679,7 @@ msgstr "Bővíthető"
 msgid "Gaphor is extensible. Plug-in a code generator or export your diagrams for documentation.  Create your own extensions and access them through the GUI or CLI."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/06-standard.md.filt
 #, no-wrap
 msgid "Standards Compliant"
@@ -696,7 +697,7 @@ msgstr ""
 
 #. type: Plain text
 #: contribute.md.filt
-msgid "Our technical documentation is hosted on the wonderful service that is Read the Docs.  Not only does it contain details needed in order to make code contributions to Gaphor, but it outlines plenty of other ways in which you can contribute (including making updates to this website). Finally, it provides a guide to our processes and expectations for the various types of contribution you can make to Gaphor."
+msgid "Our technical documentation is hosted on the wonderful service that is Read the Docs. Not only does it contain details needed in order to make code contributions to Gaphor, but it outlines plenty of other ways in which you can contribute (including making updates to this website). Finally, it provides a guide to our processes and expectations for the various types of contribution you can make to Gaphor."
 msgstr ""
 
 #. type: Plain text
@@ -801,9 +802,19 @@ msgstr ""
 msgid "Advanced topics"
 msgstr ""
 
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "Extend your models with stereotypes"
+msgstr ""
+
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "Writing a plugin"
+msgstr ""
+
 #. type: Plain text
 #: tutorials.md.filt
-msgid "- Extend your models with stereotypes - Writing a plugin - Technical and architectural documentation for contributors and plugin developers"
+msgid "- Technical and architectural documentation for contributors and plugin developers"
 msgstr ""
 
 #. type: Title ##
@@ -838,12 +849,22 @@ msgstr ""
 msgid "There are some 10+ year old articles on Gaphor on the web. Some more recent articles are:"
 msgstr ""
 
-#. type: Plain text
+#. type: Bullet: '- '
 #: tutorials.md.filt
-msgid "- Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on a Window 10.  - It's FOSS has a short write-up on Gaphor (~2.8-ish?).  - Ubuntu Pit has a nice article on Gaphor (~2.8-ish?)."
+msgid "Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on a Window 10."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "It's FOSS has a short write-up on Gaphor (~2.8-ish?)."
+msgstr ""
+
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "Ubuntu Pit has a nice article on Gaphor (~2.8-ish?)."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
 #: download.md.filt
 #, no-wrap
 msgid "Download Gaphor"
@@ -851,7 +872,7 @@ msgstr "A Gaphor letöltése"
 
 #. type: Plain text
 #: download.md.filt
-msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all the required dependencies installed."
 msgstr ""
 
 #. type: Plain text
@@ -876,34 +897,14 @@ msgstr ""
 msgid "The requested page could not be found."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: index.md.filt
 #, no-wrap
 msgid "Modeling for Everyone"
 msgstr "Műszaki modellezés mindenki számára"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: blog.md.filt
 #, no-wrap
 msgid "Blog and News"
 msgstr "Napló és hírek"
-
-#, fuzzy, no-wrap
-#~| msgid " Download installer\n"
-#~ msgid "  Download\n"
-#~ msgstr " Telepítő letöltése\n"
-
-#, fuzzy, no-wrap
-#~| msgid "Tutorials"
-#~ msgid "  Tutorials\n"
-#~ msgstr "Oktatóanyagok"
-
-#, fuzzy, no-wrap
-#~| msgid "Get in touch"
-#~ msgid "  Get in touch\n"
-#~ msgstr "Kapcsolatfelvétel"
-
-#, fuzzy, no-wrap
-#~| msgid "Contribute"
-#~ msgid "  Contribute\n"
-#~ msgstr "Közreműködés"

--- a/po/site.pot
+++ b/po/site.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-15 21:12-0300\n"
+"POT-Creation-Date: 2023-01-22 16:13-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,14 +30,14 @@ msgstr ""
 
 #. type: Plain text
 #: _includes/footer.md.filt
-#, markdown-text, no-wrap
-msgid " Tech docs\n"
+#, markdown-text
+msgid "Tech docs"
 msgstr ""
 
 #. type: Plain text
 #: _includes/footer.md.filt
 #, markdown-text
-msgid "Copyright &copy; 2020-2022 Arjan Molenaar and Dan Yeaw."
+msgid "Copyright &copy; 2020-2023 Arjan Molenaar and Dan Yeaw."
 msgstr ""
 
 #. type: Plain text
@@ -85,7 +85,7 @@ msgstr ""
 #. type: Plain text
 #: _includes/content.md.filt
 #, markdown-text
-msgid "There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+msgid "There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all the required dependencies installed."
 msgstr ""
 
 #. type: Plain text
@@ -130,7 +130,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt tutorials.md.filt
 #, markdown-text, no-wrap
 msgid "Tutorials"
@@ -142,19 +142,19 @@ msgstr ""
 msgid "Blog"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt discuss.md.filt
 #, markdown-text, no-wrap
 msgid "Get in touch"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt contribute.md.filt
 #, markdown-text, no-wrap
 msgid "Contribute"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/01-windows.md.filt
 #, no-wrap
 msgid "Windows"
@@ -178,7 +178,7 @@ msgstr ""
 msgid " Download portable version\n"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/02-macos.md.filt
 #, no-wrap
 msgid "macOS"
@@ -208,7 +208,7 @@ msgstr ""
 msgid "Pour Gaphor from a homebrew cask:"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/03-linux.md.filt
 #, no-wrap
 msgid "Linux"
@@ -268,7 +268,7 @@ msgstr ""
 msgid "Gaphor can be installed from an AUR package."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/04-python.md.filt
 #, no-wrap
 msgid "Python"
@@ -283,10 +283,10 @@ msgstr ""
 #. type: Plain text
 #: _platforms/04-python.md.filt
 #, markdown-text
-msgid "If you don't have the latest stable version of Python and the Gaphor dependencies installed, follow the development environment installation instructions section, but do not clone the repository.  Optionally, create a virtual environment.  Then execute the following:"
+msgid "If you don't have the latest stable version of Python and the Gaphor dependencies installed, follow the development environment installation instructions section, but do not clone the repository. Optionally, create a virtual environment.  Then execute the following:"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: tutorials/plugins.md.filt
 #, no-wrap
 msgid "Writing a Plugin"
@@ -343,7 +343,7 @@ msgstr ""
 #. type: Plain text
 #: tutorials/plugins.md.filt
 #, markdown-text
-msgid "`query` is a lambda function with the element as parameter. For example, to fetch all of the Class instances from the element factory:"
+msgid "`query` is a lambda function with the element as parameter. For example, to fetch all the Class instances from the element factory:"
 msgstr ""
 
 #. type: Title ##
@@ -388,7 +388,7 @@ msgstr ""
 msgid "An example Hello World plugin is hosted on GitHub."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: tutorials/report-bugs.md.filt
 #, no-wrap
 msgid "How to report a bug in Gaphor"
@@ -475,7 +475,7 @@ msgstr ""
 #. type: Plain text
 #: tutorials/report-bugs.md.filt
 #, markdown-text
-msgid "Use plain and simple language to describe the problem and, if helpful, break it down into steps so developers can easily recreate the issue. Please don't assume we'll understand what you were trying to achieve -- honestly, it's best if you try to imagine we (the developers) are a bunch of clever 5-year-olds.  Try to explain *everything* about the problem and don't assume we know what you mean. We won't mind!"
+msgid "Use plain and simple language to describe the problem and, if helpful, break it down into steps so developers can easily recreate the issue. Please don't assume we'll understand what you were trying to achieve -- honestly, it's best if you try to imagine we (the developers) are a bunch of clever 5-year-olds. Try to explain *everything* about the problem and don't assume we know what you mean.  We won't mind!"
 msgstr ""
 
 #. type: Plain text
@@ -655,7 +655,7 @@ msgstr ""
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
 #, markdown-text
-msgid "Gaphor does not make any assumptions about which elements should be placed on a diagram. A diagram is a diagram. UML defines all different kinds of diagrams, such as Class diagrams, Component diagrams, Action diagrams, Sequence diagrams. But Gaphor does not place any restrictions."
+msgid "Gaphor does not make any assumptions about which elements should be placed on a diagram. A diagram is a diagram. UML defines all different kinds of diagrams, such as Class diagrams, Component diagrams, Action diagrams, Sequence diagrams.  But Gaphor does not place any restrictions."
 msgstr ""
 
 #. type: Title ##
@@ -667,7 +667,7 @@ msgstr ""
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
 #, markdown-text
-msgid "To create a new diagram, use the Navigation section. Select an element that can contain a diagram (a Package or Profile) and right-click. Select New diagram and a new diagram is created. As of Gaphor 1.1.0 a buttion is available in the header bar. Select a package and you'll notice the button is not grayed out and can be clicked, resulting in a new diagram being added to the model."
+msgid "To create a new diagram, use the Navigation section. Select an element that can contain a diagram (a Package or Profile) and right-click. Select New diagram and a new diagram is created. As of Gaphor 1.1.0 a buttion is available in the header bar. Select a package, and you'll notice the button is not grayed out and can be clicked, resulting in a new diagram being added to the model."
 msgstr ""
 
 #. type: Title ##
@@ -685,7 +685,7 @@ msgstr ""
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
 #, markdown-text
-msgid "This way you can easely create visual copies of the same (underlaying) model element."
+msgid "This way you can easily create visual copies of the same (underlying) model element."
 msgstr ""
 
 #. type: Title ##
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Elements can also be dragged within the Navigation section. This way classes and packages can be rearranged for example."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/01-platform.md.filt
 #, no-wrap
 msgid "Multi-platform"
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Gaphor works on all major platforms: Windows, Macos and Linux."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/02-opensource.md.filt
 #, no-wrap
 msgid "Open Source"
@@ -730,7 +730,7 @@ msgstr ""
 msgid "No vendor lock-in: Gaphor written in Python and is 100% Open Source, available under a friendly Apache 2 license."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/03-beginner-pro.md.filt
 #, no-wrap
 msgid "Beginner or Pro"
@@ -742,7 +742,7 @@ msgstr ""
 msgid "Whether you're a casual modeler documenting a project or a Model Driven Development expert, Gaphor has got you covered."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/04-consistent.md.filt
 #, no-wrap
 msgid "Consistent"
@@ -754,7 +754,7 @@ msgstr ""
 msgid "UML is a graphical modeling language, so all information you put in the model is visible in the diagrams. For example, stereotypes are modeled in diagrams.  No hidden panels and property pages. Just diagrams!"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/05-extensible.md.filt
 #, no-wrap
 msgid "Extensible"
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Gaphor is extensible. Plug-in a code generator or export your diagrams for documentation.  Create your own extensions and access them through the GUI or CLI."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/06-standard.md.filt
 #, no-wrap
 msgid "Standards Compliant"
@@ -787,7 +787,7 @@ msgstr ""
 #. type: Plain text
 #: contribute.md.filt
 #, markdown-text
-msgid "Our technical documentation is hosted on the wonderful service that is Read the Docs.  Not only does it contain details needed in order to make code contributions to Gaphor, but it outlines plenty of other ways in which you can contribute (including making updates to this website). Finally, it provides a guide to our processes and expectations for the various types of contribution you can make to Gaphor."
+msgid "Our technical documentation is hosted on the wonderful service that is Read the Docs. Not only does it contain details needed in order to make code contributions to Gaphor, but it outlines plenty of other ways in which you can contribute (including making updates to this website). Finally, it provides a guide to our processes and expectations for the various types of contribution you can make to Gaphor."
 msgstr ""
 
 #. type: Plain text
@@ -902,10 +902,22 @@ msgstr ""
 msgid "Advanced topics"
 msgstr ""
 
+#. type: Bullet: '- '
+#: tutorials.md.filt
+#, markdown-text
+msgid "Extend your models with stereotypes"
+msgstr ""
+
+#. type: Bullet: '- '
+#: tutorials.md.filt
+#, markdown-text
+msgid "Writing a plugin"
+msgstr ""
+
 #. type: Plain text
 #: tutorials.md.filt
 #, markdown-text
-msgid "- Extend your models with stereotypes - Writing a plugin - Technical and architectural documentation for contributors and plugin developers"
+msgid "- Technical and architectural documentation for contributors and plugin developers"
 msgstr ""
 
 #. type: Title ##
@@ -944,13 +956,25 @@ msgstr ""
 msgid "There are some 10+ year old articles on Gaphor on the web. Some more recent articles are:"
 msgstr ""
 
-#. type: Plain text
+#. type: Bullet: '- '
 #: tutorials.md.filt
 #, markdown-text
-msgid "- Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on a Window 10.  - It's FOSS has a short write-up on Gaphor (~2.8-ish?).  - Ubuntu Pit has a nice article on Gaphor (~2.8-ish?)."
+msgid "Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on a Window 10."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Bullet: '- '
+#: tutorials.md.filt
+#, markdown-text
+msgid "It's FOSS has a short write-up on Gaphor (~2.8-ish?)."
+msgstr ""
+
+#. type: Bullet: '- '
+#: tutorials.md.filt
+#, markdown-text
+msgid "Ubuntu Pit has a nice article on Gaphor (~2.8-ish?)."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
 #: download.md.filt
 #, no-wrap
 msgid "Download Gaphor"
@@ -959,7 +983,7 @@ msgstr ""
 #. type: Plain text
 #: download.md.filt
 #, markdown-text
-msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all the required dependencies installed."
 msgstr ""
 
 #. type: Plain text
@@ -986,13 +1010,13 @@ msgstr ""
 msgid "The requested page could not be found."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: index.md.filt
 #, no-wrap
 msgid "Modeling for Everyone"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: blog.md.filt
 #, no-wrap
 msgid "Blog and News"

--- a/po/site.ru.po
+++ b/po/site.ru.po
@@ -6,17 +6,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-15 21:12-0300\n"
+"POT-Creation-Date: 2023-01-22 16:01-0500\n"
 "PO-Revision-Date: 2023-01-18 14:49+0000\n"
 "Last-Translator: BrainKicker <peter.sabanov@gmail.com>\n"
-"Language-Team: Russian <https://hosted.weblate.org/projects/gaphor/"
-"gaphor-github-io/ru/>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/gaphor/gaphor-github-io/ru/>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.15.1-dev\n"
 
 #. type: Plain text
@@ -31,13 +29,12 @@ msgstr ""
 
 #. type: Plain text
 #: _includes/footer.md.filt
-#, no-wrap
-msgid " Tech docs\n"
+msgid "Tech docs"
 msgstr ""
 
 #. type: Plain text
 #: _includes/footer.md.filt
-msgid "Copyright &copy; 2020-2022 Arjan Molenaar and Dan Yeaw."
+msgid "Copyright &copy; 2020-2023 Arjan Molenaar and Dan Yeaw."
 msgstr ""
 
 #. type: Plain text
@@ -48,9 +45,7 @@ msgstr ""
 #. type: Plain text
 #: _includes/content.md.filt
 msgid "A picture is worth a thousand words. Describe and document your applications and systems with Gaphor to enhance knowledge sharing."
-msgstr ""
-"Картинка стоит тысячи слов. Описывайте и документируйте свои приложения и "
-"системы с помощью Gaphor, чтобы улучшить обмен знаниями."
+msgstr "Картинка стоит тысячи слов. Описывайте и документируйте свои приложения и системы с помощью Gaphor, чтобы улучшить обмен знаниями."
 
 #. type: Plain text
 #: _includes/content.md.filt
@@ -79,7 +74,7 @@ msgstr ""
 
 #. type: Plain text
 #: _includes/content.md.filt
-msgid "There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+msgid "There are many ways to install Gaphor.  The simplest is to download the official installer for Windows or macOS.  For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all the required dependencies installed."
 msgstr ""
 
 #. type: Plain text
@@ -117,7 +112,7 @@ msgstr "Узнать больше"
 msgid "About"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt tutorials.md.filt
 #, no-wrap
 msgid "Tutorials"
@@ -128,19 +123,19 @@ msgstr ""
 msgid "Blog"
 msgstr "Блог"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt discuss.md.filt
 #, no-wrap
 msgid "Get in touch"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _includes/content.md.filt contribute.md.filt
 #, no-wrap
 msgid "Contribute"
 msgstr "Участвовать"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/01-windows.md.filt
 #, no-wrap
 msgid "Windows"
@@ -163,7 +158,7 @@ msgstr ""
 msgid " Download portable version\n"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/02-macos.md.filt
 #, no-wrap
 msgid "macOS"
@@ -191,7 +186,7 @@ msgstr ""
 msgid "Pour Gaphor from a homebrew cask:"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/03-linux.md.filt
 #, no-wrap
 msgid "Linux"
@@ -246,7 +241,7 @@ msgstr "Arch Linux"
 msgid "Gaphor can be installed from an AUR package."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _platforms/04-python.md.filt
 #, no-wrap
 msgid "Python"
@@ -259,10 +254,10 @@ msgstr ""
 
 #. type: Plain text
 #: _platforms/04-python.md.filt
-msgid "If you don't have the latest stable version of Python and the Gaphor dependencies installed, follow the development environment installation instructions section, but do not clone the repository.  Optionally, create a virtual environment.  Then execute the following:"
+msgid "If you don't have the latest stable version of Python and the Gaphor dependencies installed, follow the development environment installation instructions section, but do not clone the repository. Optionally, create a virtual environment.  Then execute the following:"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: tutorials/plugins.md.filt
 #, no-wrap
 msgid "Writing a Plugin"
@@ -312,7 +307,7 @@ msgstr ""
 
 #. type: Plain text
 #: tutorials/plugins.md.filt
-msgid "`query` is a lambda function with the element as parameter. For example, to fetch all of the Class instances from the element factory:"
+msgid "`query` is a lambda function with the element as parameter. For example, to fetch all the Class instances from the element factory:"
 msgstr ""
 
 #. type: Title ##
@@ -352,7 +347,7 @@ msgstr ""
 msgid "An example Hello World plugin is hosted on GitHub."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: tutorials/report-bugs.md.filt
 #, no-wrap
 msgid "How to report a bug in Gaphor"
@@ -425,7 +420,7 @@ msgstr ""
 
 #. type: Plain text
 #: tutorials/report-bugs.md.filt
-msgid "Use plain and simple language to describe the problem and, if helpful, break it down into steps so developers can easily recreate the issue. Please don't assume we'll understand what you were trying to achieve -- honestly, it's best if you try to imagine we (the developers) are a bunch of clever 5-year-olds.  Try to explain *everything* about the problem and don't assume we know what you mean. We won't mind!"
+msgid "Use plain and simple language to describe the problem and, if helpful, break it down into steps so developers can easily recreate the issue. Please don't assume we'll understand what you were trying to achieve -- honestly, it's best if you try to imagine we (the developers) are a bunch of clever 5-year-olds. Try to explain *everything* about the problem and don't assume we know what you mean.  We won't mind!"
 msgstr ""
 
 #. type: Plain text
@@ -442,9 +437,7 @@ msgstr "Начните работу с Gaphor"
 #. type: Plain text
 #: tutorials/get-started-with-gaphor.md.filt
 msgid "Once Gaphor is launched, it provides you an almost empty user interface.  A new model is already created and the diagram is opened."
-msgstr ""
-"Как только Gaphor запущен, он предоставляет вам почти пустой "
-"пользовательский интерфейс.  Новая модель уже создана, и диаграмма открыта."
+msgstr "Как только Gaphor запущен, он предоставляет вам почти пустой пользовательский интерфейс.  Новая модель уже создана, и диаграмма открыта."
 
 #. type: Plain text
 #: tutorials/get-started-with-gaphor.md.filt
@@ -583,7 +576,7 @@ msgstr ""
 
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
-msgid "Gaphor does not make any assumptions about which elements should be placed on a diagram. A diagram is a diagram. UML defines all different kinds of diagrams, such as Class diagrams, Component diagrams, Action diagrams, Sequence diagrams. But Gaphor does not place any restrictions."
+msgid "Gaphor does not make any assumptions about which elements should be placed on a diagram. A diagram is a diagram. UML defines all different kinds of diagrams, such as Class diagrams, Component diagrams, Action diagrams, Sequence diagrams.  But Gaphor does not place any restrictions."
 msgstr ""
 
 #. type: Title ##
@@ -594,7 +587,7 @@ msgstr ""
 
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
-msgid "To create a new diagram, use the Navigation section. Select an element that can contain a diagram (a Package or Profile) and right-click. Select New diagram and a new diagram is created. As of Gaphor 1.1.0 a buttion is available in the header bar. Select a package and you'll notice the button is not grayed out and can be clicked, resulting in a new diagram being added to the model."
+msgid "To create a new diagram, use the Navigation section. Select an element that can contain a diagram (a Package or Profile) and right-click. Select New diagram and a new diagram is created. As of Gaphor 1.1.0 a buttion is available in the header bar. Select a package, and you'll notice the button is not grayed out and can be clicked, resulting in a new diagram being added to the model."
 msgstr ""
 
 #. type: Title ##
@@ -610,7 +603,7 @@ msgstr ""
 
 #. type: Plain text
 #: tutorials/your-first-model.md.filt
-msgid "This way you can easely create visual copies of the same (underlaying) model element."
+msgid "This way you can easily create visual copies of the same (underlying) model element."
 msgstr ""
 
 #. type: Title ##
@@ -629,7 +622,7 @@ msgstr ""
 msgid "Elements can also be dragged within the Navigation section. This way classes and packages can be rearranged for example."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/01-platform.md.filt
 #, no-wrap
 msgid "Multi-platform"
@@ -640,7 +633,7 @@ msgstr ""
 msgid "Gaphor works on all major platforms: Windows, Macos and Linux."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/02-opensource.md.filt
 #, no-wrap
 msgid "Open Source"
@@ -651,7 +644,7 @@ msgstr ""
 msgid "No vendor lock-in: Gaphor written in Python and is 100% Open Source, available under a friendly Apache 2 license."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/03-beginner-pro.md.filt
 #, no-wrap
 msgid "Beginner or Pro"
@@ -662,7 +655,7 @@ msgstr ""
 msgid "Whether you're a casual modeler documenting a project or a Model Driven Development expert, Gaphor has got you covered."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/04-consistent.md.filt
 #, no-wrap
 msgid "Consistent"
@@ -673,7 +666,7 @@ msgstr ""
 msgid "UML is a graphical modeling language, so all information you put in the model is visible in the diagrams. For example, stereotypes are modeled in diagrams.  No hidden panels and property pages. Just diagrams!"
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/05-extensible.md.filt
 #, no-wrap
 msgid "Extensible"
@@ -684,7 +677,7 @@ msgstr ""
 msgid "Gaphor is extensible. Plug-in a code generator or export your diagrams for documentation.  Create your own extensions and access them through the GUI or CLI."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: _usps/06-standard.md.filt
 #, no-wrap
 msgid "Standards Compliant"
@@ -702,7 +695,7 @@ msgstr ""
 
 #. type: Plain text
 #: contribute.md.filt
-msgid "Our technical documentation is hosted on the wonderful service that is Read the Docs.  Not only does it contain details needed in order to make code contributions to Gaphor, but it outlines plenty of other ways in which you can contribute (including making updates to this website). Finally, it provides a guide to our processes and expectations for the various types of contribution you can make to Gaphor."
+msgid "Our technical documentation is hosted on the wonderful service that is Read the Docs. Not only does it contain details needed in order to make code contributions to Gaphor, but it outlines plenty of other ways in which you can contribute (including making updates to this website). Finally, it provides a guide to our processes and expectations for the various types of contribution you can make to Gaphor."
 msgstr ""
 
 #. type: Plain text
@@ -807,9 +800,19 @@ msgstr ""
 msgid "Advanced topics"
 msgstr ""
 
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "Extend your models with stereotypes"
+msgstr ""
+
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "Writing a plugin"
+msgstr ""
+
 #. type: Plain text
 #: tutorials.md.filt
-msgid "- Extend your models with stereotypes - Writing a plugin - Technical and architectural documentation for contributors and plugin developers"
+msgid "- Technical and architectural documentation for contributors and plugin developers"
 msgstr ""
 
 #. type: Title ##
@@ -844,12 +847,22 @@ msgstr ""
 msgid "There are some 10+ year old articles on Gaphor on the web. Some more recent articles are:"
 msgstr ""
 
-#. type: Plain text
+#. type: Bullet: '- '
 #: tutorials.md.filt
-msgid "- Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on a Window 10.  - It's FOSS has a short write-up on Gaphor (~2.8-ish?).  - Ubuntu Pit has a nice article on Gaphor (~2.8-ish?)."
+msgid "Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on a Window 10."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "It's FOSS has a short write-up on Gaphor (~2.8-ish?)."
+msgstr ""
+
+#. type: Bullet: '- '
+#: tutorials.md.filt
+msgid "Ubuntu Pit has a nice article on Gaphor (~2.8-ish?)."
+msgstr ""
+
+#. type: Yaml Front Matter Hash Value: title
 #: download.md.filt
 #, no-wrap
 msgid "Download Gaphor"
@@ -857,7 +870,7 @@ msgstr ""
 
 #. type: Plain text
 #: download.md.filt
-msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all of the required dependencies installed."
+msgid "There are many ways to install Gaphor. The simplest is to download the official installer for Windows or macOS. For Linux you can install Gaphor using FlatHub.  You can also use Python's built-in `pip` tool as long as you have all the required dependencies installed."
 msgstr ""
 
 #. type: Plain text
@@ -882,13 +895,13 @@ msgstr "**Страница не найдена :(**\n"
 msgid "The requested page could not be found."
 msgstr ""
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: index.md.filt
 #, no-wrap
 msgid "Modeling for Everyone"
 msgstr "Моделирование для Всех"
 
-#. type: YAML Front Matter: title
+#. type: Yaml Front Matter Hash Value: title
 #: blog.md.filt
 #, no-wrap
 msgid "Blog and News"

--- a/ru/404.md
+++ b/ru/404.md
@@ -7,6 +7,6 @@ title: 404
 
 # 404
 
-**Page not found :(**
+**Страница не найдена :(**
 
 The requested page could not be found.

--- a/ru/_includes/content.md
+++ b/ru/_includes/content.md
@@ -1,59 +1,121 @@
-{% capture thousand-words %} A picture is worth a thousand words. Describe
-and document your applications and systems with Gaphor to enhance knowledge
-sharing.  {% endcapture %}
+{% capture thousand-words %}
 
-{% capture about-content %} Gaphor is a UML, SysML, RAAML, and C4 modeling
-application. It is designed to be easy to use, while still being
-powerful. Gaphor implements a fully-compliant UML 2 data model, so it is
-much more than a picture drawing tool. You can use Gaphor to quickly
-visualize different aspects of a system as well as create complete, highly
-complex models.
+Картинка стоит тысячи слов. Описывайте и документируйте свои приложения и
+системы с помощью Gaphor, чтобы улучшить обмен знаниями.
 
 {% endcapture %}
 
-{% capture build %} Build Class, Interaction, and State Machine diagrams for
-software or Block Definition and Requirements diagrams for systems. Model
-the elements you need. If you want to mix and match, you can even add
-different diagram items to the same diagram to get the view you need.  {%
-endcapture %}
+{% capture about-content %}
 
-{% capture styling-engine %} Customize the diagrams you create with our
-built-in styling engine.  {% endcapture %}
+Gaphor is a UML, SysML, RAAML, and C4 modeling application. It is designed
+to be easy to use, while still being powerful. Gaphor implements a
+fully-compliant UML 2 data model, so it is much more than a picture drawing
+tool. You can use Gaphor to quickly visualize different aspects of a system
+as well as create complete, highly complex models.
 
-{% capture treeview %} Easily find all element of your model in the tree
-view.  {% endcapture %}
+{% endcapture %}
 
-{% capture dark-mode %} Love dark mode? We can do that too.  {% endcapture
-%}
+{% capture build %}
 
-{% capture download-content %} There are many ways to install Gaphor.  The
-simplest is to download the official installer for Windows or macOS.  For
-Linux you can install Gaphor using FlatHub.  You can also use Python's
-built-in `pip` tool as long as you have all of the required dependencies
-installed.  {% endcapture %}
+Build Class, Interaction, and State Machine diagrams for software or Block
+Definition and Requirements diagrams for systems. Model the elements you
+need. If you want to mix and match, you can even add different diagram items
+to the same diagram to get the view you need.
 
-{% capture blog-content %} Do you want to know what's going on with Gaphor?
-Read our blog!
+{% endcapture %}
+
+{% capture styling-engine %}
+
+Customize the diagrams you create with our built-in styling engine.
+
+{% endcapture %}
+
+{% capture treeview %}
+
+Easily find all element of your model in the tree view.
+
+{% endcapture %}
+
+{% capture dark-mode %}
+
+Love dark mode? We can do that too.
+
+{% endcapture %}
+
+{% capture download-content %}
+
+There are many ways to install Gaphor.  The simplest is to download the
+official installer for Windows or macOS.  For Linux you can install Gaphor
+using FlatHub.  You can also use Python's built-in `pip` tool as long as you
+have all the required dependencies installed.
+
+{% endcapture %}
+
+{% capture blog-content %}
+
+Хотите знать, что происходит с Gaphor? Читайте наш блог!
 
 [Contact the team]({% link discuss.md %})  if you want to share content
-related to Gaphor.  {% endcapture %}
+related to Gaphor.
 
-{% capture see-blog %} See blog {% endcapture %}
+{% endcapture %}
 
-{% capture read-more %} Read more {% endcapture %}
+{% capture see-blog %}
 
-{% capture download %} Download {% endcapture %}
+See blog
 
-{% capture learn %} Learn more {% endcapture %}
+{% endcapture %}
 
-{% capture about %} About {% endcapture %}
+{% capture read-more %}
 
-{% capture download %} Download {% endcapture %}
+Read more
 
-{% capture tutorials %} Tutorials {% endcapture %}
+{% endcapture %}
 
-{% capture blog %} Blog {% endcapture %}
+{% capture download %}
 
-{% capture discuss %} Get in touch {% endcapture %}
+Загрузить
 
-{% capture contribute %} Contribute {% endcapture %}
+{% endcapture %}
+
+{% capture learn %}
+
+Узнать больше
+
+{% endcapture %}
+
+{% capture about %}
+
+About
+
+{% endcapture %}
+
+{% capture download %}
+
+Загрузить
+
+{% endcapture %}
+
+{% capture tutorials %}
+
+Tutorials
+
+{% endcapture %}
+
+{% capture blog %}
+
+Блог
+
+{% endcapture %}
+
+{% capture discuss %}
+
+Get in touch
+
+{% endcapture %}
+
+{% capture contribute %}
+
+Участвовать
+
+{% endcapture %}

--- a/ru/_includes/footer.md
+++ b/ru/_includes/footer.md
@@ -1,12 +1,29 @@
-{% capture love %} We love to hear from you {% endcapture %}
+{% capture love %}
 
-{% capture open-issue %} Open an issue on GitHub {% endcapture %}
+We love to hear from you
 
-{% capture tech-docs %}
- Tech docs
 {% endcapture %}
 
-{% capture copyright %} Copyright &copy; 2020-2022 Arjan Molenaar and Dan
-Yeaw.  {% endcapture %}
+{% capture open-issue %}
 
-{% capture theme %} Theme {% endcapture %}
+Open an issue on GitHub
+
+{% endcapture %}
+
+{% capture tech-docs %}
+
+Tech docs
+
+{% endcapture %}
+
+{% capture copyright %}
+
+Copyright &copy; 2020-2023 Arjan Molenaar and Dan Yeaw.
+
+{% endcapture %}
+
+{% capture theme %}
+
+Theme
+
+{% endcapture %}

--- a/ru/_platforms/04-python.md
+++ b/ru/_platforms/04-python.md
@@ -10,8 +10,8 @@ dependencies installed, you can also install Gaphor using a wheel from
 
 If you don't have the latest stable version of Python and the Gaphor
 dependencies installed, follow the development environment [installation
-instructions](https://gaphor.readthedocs.io/en/latest/)  section, but do not
-clone the repository.  Optionally, create a [virtual
+instructions](https://gaphor.readthedocs.io/en/latest/) section, but do not
+clone the repository. Optionally, create a [virtual
 environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments).
 Then execute the following:
 

--- a/ru/blog.md
+++ b/ru/blog.md
@@ -2,5 +2,5 @@
 handle: /blog
 language: ru
 layout: blog
-title: 'Blog and News'
+title: 'Блог и Новости'
 ---

--- a/ru/contribute.md
+++ b/ru/contribute.md
@@ -3,7 +3,7 @@ handle: /contribute
 language: ru
 layout: article
 redirect_from: /pages/developers.html
-title: Contribute
+title: Участвовать
 ---
 
 Would you like to contribute to the development of Gaphor? (If you think
@@ -12,9 +12,9 @@ are plenty of ways to contribute to Gaphor, no matter your level of
 experience or skill set.
 
 Our [technical documentation](https://gaphor.readthedocs.io) is hosted on
-the wonderful service that is [Read the Docs](https://readthedocs.com/).
-Not only does it contain details needed in order to make code contributions
-to Gaphor, but it outlines plenty of other ways in which you can contribute
+the wonderful service that is [Read the Docs](https://readthedocs.com/). Not
+only does it contain details needed in order to make code contributions to
+Gaphor, but it outlines plenty of other ways in which you can contribute
 (including making updates to this website). Finally, it provides a guide to
 our processes and expectations for the various types of contribution you can
 make to Gaphor.

--- a/ru/download.md
+++ b/ru/download.md
@@ -14,7 +14,7 @@ title: 'Download Gaphor'
 There are many ways to install Gaphor. The simplest is to download the
 official installer for Windows or macOS. For Linux you can install Gaphor
 using FlatHub.  You can also use Python's built-in `pip` tool as long as you
-have all of the required dependencies installed.
+have all the required dependencies installed.
 
 If you're a developer, you can find the source code [on
 GitHub](https://github.com/gaphor/gaphor).

--- a/ru/index.md
+++ b/ru/index.md
@@ -3,5 +3,5 @@ handle: /index
 language: ru
 layout: index
 redirect_from: /pages/about.html
-title: 'Modeling for Everyone'
+title: 'Моделирование для Всех'
 ---

--- a/ru/tutorials.md
+++ b/ru/tutorials.md
@@ -21,10 +21,11 @@ Michigan Python meetup.
 ## Advanced topics
 
 - [Extend your models with
-stereotypes](https://gaphor.readthedocs.io/en/latest/stereotypes.html)  -
-[Writing a plugin]({% link tutorials/plugins.md %})  - [Technical and
-architectural documentation](https://gaphor.readthedocs.io/)  for
-contributors and plugin developers
+  stereotypes](https://gaphor.readthedocs.io/en/latest/stereotypes.html)
+- [Writing a plugin]({% link tutorials/plugins.md %})
+- [Technical and architectural
+documentation](https://gaphor.readthedocs.io/)  for contributors and plugin
+developers
 
 ## Talks
 
@@ -45,8 +46,8 @@ There are some 10+ year old articles on Gaphor on the web. Some more recent
 articles are:
 
 - [Methods & Tools website reviewed Gaphor version 2.7.1 in December 2021 on
-a Window 10.](https://www.methodsandtools.com/tools/gaphor.php)  - [It's
-FOSS has a short write-up on Gaphor
-(~2.8-ish?).](https://itsfoss.com/gaphor-modeling-tool/)  - [Ubuntu Pit has
-a nice article on Gaphor
-(~2.8-ish?).](https://www.ubuntupit.com/gaphor-an-open-source-simple-graphical-modeling-tool/)
+  a Window 10.](https://www.methodsandtools.com/tools/gaphor.php)
+- [It's FOSS has a short write-up on Gaphor
+  (~2.8-ish?).](https://itsfoss.com/gaphor-modeling-tool/)
+- [Ubuntu Pit has a nice article on Gaphor
+  (~2.8-ish?).](https://www.ubuntupit.com/gaphor-an-open-source-simple-graphical-modeling-tool/)

--- a/ru/tutorials/get-started-with-gaphor.md
+++ b/ru/tutorials/get-started-with-gaphor.md
@@ -3,22 +3,22 @@ handle: /tutorials/get-started-with-gaphor
 language: ru
 layout: article
 redirect_from: /pages/your-first-model.html
-title: 'Get started with Gaphor'
+title: 'Начните работу с Gaphor'
 ---
 
-Once Gaphor is launched, it provides you an almost empty user interface.  A
-new model is already created and the diagram is opened.
+Как только Gaphor запущен, он предоставляет вам почти пустой
+пользовательский интерфейс.  Новая модель уже создана, и диаграмма открыта.
 
-The layout of the Gaphor interface is divided into four sections, namely:
+Структура интерфейса Gaphor разделена на четыре секции, а именно:
 
--   Navigation
--   Diagrams
--   Diagram Element Toolbox
--   Properties pane
+-   Навигация
+-   Диаграммы
+-   Панель Элементов Диаграммы
+-   Панель свойств
 
-Each section has its own specific function.
+Каждая секция имеет свою определённую функцию.
 
-## Navigation
+## Навигация
 
 The navigation section of the interface displays a hierarchical view of your
 model. Every model element you create will be inserted into the navigation

--- a/ru/tutorials/plugins.md
+++ b/ru/tutorials/plugins.md
@@ -5,6 +5,7 @@ layout: article
 redirect_from: /pages/writing-a-plugin.html
 title: 'Writing a Plugin'
 ---
+
 Gaphor is designed to be extensible by using plugins that allow you to
 extend the functionality.
 
@@ -39,7 +40,7 @@ Two methods are used for querying:
 -   `lselect(query=None)` -> returns a list
 
 `query` is a lambda function with the element as parameter. For example, to
-fetch all of the Class instances from the element factory:
+fetch all the Class instances from the element factory:
 
 ```python
 element_factory.select(lambda e: e.isKindOf(UML.Class))

--- a/ru/tutorials/report-bugs.md
+++ b/ru/tutorials/report-bugs.md
@@ -43,8 +43,8 @@ Use plain and simple language to describe the problem and, if helpful, break
 it down into steps so developers can easily recreate the issue. Please don't
 assume we'll understand what you were trying to achieve -- honestly, it's
 best if you try to imagine we (the developers) are a bunch of clever
-5-year-olds.  Try to explain *everything* about the problem and don't assume
-we know what you mean. We won't mind!
+5-year-olds. Try to explain *everything* about the problem and don't assume
+we know what you mean.  We won't mind!
 
 If you would like to get more involved in the development of Gaphor, we'd
 love to welcome you via the [Gaphor developer's

--- a/ru/tutorials/your-first-model.md
+++ b/ru/tutorials/your-first-model.md
@@ -25,7 +25,7 @@ collapsed and needs to be clicked first to reveal its contents.
 Gaphor does not make any assumptions about which elements should be placed
 on a diagram. A diagram is a diagram. UML defines all different kinds of
 diagrams, such as Class diagrams, Component diagrams, Action diagrams,
-Sequence diagrams. But Gaphor does not place any restrictions.
+Sequence diagrams.  But Gaphor does not place any restrictions.
 
 ## Creating New Diagrams
 
@@ -34,21 +34,21 @@ Sequence diagrams. But Gaphor does not place any restrictions.
 To create a new diagram, use the Navigation section. Select an element that
 can contain a diagram (a Package or Profile) and right-click. Select New
 diagram and a new diagram is created. As of Gaphor 1.1.0 a buttion is
-available in the header bar. Select a package and you'll notice the button
+available in the header bar. Select a package, and you'll notice the button
 is not grayed out and can be clicked, resulting in a new diagram being added
 to the model.
 
-## Copy and Paste
+## Копирование и Вставка
 
 Items in a diagram can be copied and pasted (in the same diagram or
 another). A paste will create new items in the diagrams, the items they
 represent (e.g. the Class that's shown in the Navigation) is *not* copied
 (call it a shallow copy if you like).
 
-This way you can easely create visual copies of the same (underlaying) model
+This way you can easily create visual copies of the same (underlying) model
 element.
 
-## Drag and Drop
+## Перетаскивание
 
 Adding an existing element to a diagram is simple: drag the element from the
 Navigation section onto a diagram. Not all elements that show up in the

--- a/tutorials/plugins.md
+++ b/tutorials/plugins.md
@@ -5,17 +5,17 @@ language: en
 handle: /tutorials/plugins
 layout: article
 ---
+
 Gaphor is designed to be extensible by using plugins that allow you to extend
 the functionality.
 
 ## Accessing Model Related Data
 
 The datamodel classes are located in the `gaphor.UML` module. Data objects can
-be accessed through the ElementFactory. This is a special class for creating
-and managing data objects. Items can be queried using this element factory,
-which is registered in the application as `element_factory`. When writing a
-service or plugin the element factory can be injected into the service like
-this:
+be accessed through the ElementFactory. This is a special class for creating and
+managing data objects. Items can be queried using this element factory, which is
+registered in the application as `element_factory`. When writing a service or
+plugin the element factory can be injected into the service like this:
 
 ```python
 class MyThing:
@@ -39,7 +39,7 @@ Two methods are used for querying:
 -   `lselect(query=None)` -> returns a list
 
 `query` is a lambda function with the element as parameter. For example, to
-fetch all of the Class instances from the element factory:
+fetch all the Class instances from the element factory:
 
 ```python
 element_factory.select(lambda e: e.isKindOf(UML.Class))
@@ -71,8 +71,8 @@ for o in classes.ownedOperation['it.returnParameter'].ownedParameter:
     do_something(p)
 ```
 
-The variable `it` in the query refers to the evaluated object (in this
-case all operations with a return parameter are taken into account).
+The variable `it` in the query refers to the evaluated object (in this case all
+operations with a return parameter are taken into account).
 
 ## Example Plugin
 

--- a/tutorials/report-bugs.md
+++ b/tutorials/report-bugs.md
@@ -7,20 +7,20 @@ layout: article
 ---
 
 If you've ever written a line of code, you'll know that all software has bugs.
-This will also be the case with Gaphor. If you think you have found a bug, simply
-click on the link below (you'll need to have an account on GitHub) and then
-click the green "New Issue" button found at the top right hand side of the
+This will also be the case with Gaphor. If you think you have found a bug,
+simply click on the link below (you'll need to have an account on GitHub) and
+then click the green "New Issue" button found at the top right hand side of the
 page:
 
 [Report a Bug in Gaphor](https://github.com/gaphor/gaphor/issues)
 
 When you create a new issue it will be given a number and the volunteer
-developers, who write and maintain the code, will be informed by email. They
-may annotate questions to your issue, if things are not clear. They may
-immediately close it and mark it as "duplicate" (someone else has already
-reported the bug -- and they'll reference the original issue). Sometimes
-they'll close the bug and say "won't fix", because they disagree that it's a
-bug *or* it's too trivial in order to invest any time.
+developers, who write and maintain the code, will be informed by email. They may
+annotate questions to your issue, if things are not clear. They may immediately
+close it and mark it as "duplicate" (someone else has already reported the bug
+-- and they'll reference the original issue). Sometimes they'll close the bug
+and say "won't fix", because they disagree that it's a bug *or* it's too trivial
+in order to invest any time.
 
 There are generally two sorts of bugs:
 
@@ -39,12 +39,13 @@ relevant, the following sorts of information:
 * Technical details like the version of Gaphor you're using, your OS version and
   other aspects of the context in which Gaphor was running.
 
-Use plain and simple language to describe the problem and, if helpful, break
-it down into steps so developers can easily recreate the issue. Please don't
-assume we'll understand what you were trying to achieve -- honestly, it's best
-if you try to imagine we (the developers) are a bunch of clever 5-year-olds.
-Try to explain *everything* about the problem and don't assume we know what you
-mean. We won't mind!
+Use plain and simple language to describe the problem and, if helpful, break it
+down into steps so developers can easily recreate the issue. Please don't assume
+we'll understand what you were trying to achieve -- honestly, it's best if you
+try to imagine we (the developers) are a bunch of clever 5-year-olds. Try to
+explain *everything* about the problem and don't assume we know what you mean.
+We won't mind!
 
-If you would like to get more involved in the development of Gaphor, we'd love to
-welcome you via the [Gaphor developer's website](http://gaphor.readthedocs.io/).
+If you would like to get more involved in the development of Gaphor, we'd love
+to welcome you via the [Gaphor developer's
+website](http://gaphor.readthedocs.io/).

--- a/tutorials/your-first-model.md
+++ b/tutorials/your-first-model.md
@@ -6,45 +6,46 @@ handle: /tutorials/your-first-model
 layout: article
 ---
 
-Once Gaphor is started a new empty model is automatically created. The
-main diagram is already open in the Diagram section.
+Once Gaphor is started a new empty model is automatically created. The main
+diagram is already open in the Diagram section.
 
 Select an element you want to place (e.g. a class) by clicking on the icon in
 the Toolbox and click on the diagram. This will place a new Class item instance
 on the diagram and add a new Class to the model (it shows up in the Navigation.
-The selected tool will reset itself to the Pointer tool after the element is placed
-on the diagram.
+The selected tool will reset itself to the Pointer tool after the element is
+placed on the diagram.
 
 ![image](/images/oneclass.png)
 
 It's simple to add elements to a diagram.
 
-Some elements are not directly visible. The section in the toolbox is
-collapsed and needs to be clicked first to reveal its contents.
+Some elements are not directly visible. The section in the toolbox is collapsed
+and needs to be clicked first to reveal its contents.
 
-Gaphor does not make any assumptions about which elements should be
-placed on a diagram. A diagram is a diagram. UML defines all different
-kinds of diagrams, such as Class diagrams, Component diagrams, Action
-diagrams, Sequence diagrams. But Gaphor does not place any restrictions.
+Gaphor does not make any assumptions about which elements should be placed on a
+diagram. A diagram is a diagram. UML defines all different kinds of diagrams,
+such as Class diagrams, Component diagrams, Action diagrams, Sequence diagrams.
+But Gaphor does not place any restrictions.
 
 ## Creating New Diagrams
 
 ![image](/images/navpopup.png)
 
 To create a new diagram, use the Navigation section. Select an element that can
-contain a diagram (a Package or Profile) and right-click. Select New diagram
-and a new diagram is created. As of Gaphor 1.1.0 a buttion is available in the
-header bar. Select a package and you'll notice the button is not grayed out and
+contain a diagram (a Package or Profile) and right-click. Select New diagram and
+a new diagram is created. As of Gaphor 1.1.0 a buttion is available in the
+header bar. Select a package, and you'll notice the button is not grayed out and
 can be clicked, resulting in a new diagram being added to the model.
 
 ## Copy and Paste
 
-Items in a diagram can be copied and pasted (in the same diagram or
-another). A paste will create new items in the diagrams, the items they
-represent (e.g. the Class that's shown in the Navigation) is *not*
-copied (call it a shallow copy if you like).
+Items in a diagram can be copied and pasted (in the same diagram or another). A
+paste will create new items in the diagrams, the items they represent (e.g. the
+Class that's shown in the Navigation) is *not* copied (call it a shallow copy if
+you like).
 
-This way you can easely create visual copies of the same (underlaying) model element.
+This way you can easily create visual copies of the same (underlying) model
+element.
 
 ## Drag and Drop
 


### PR DESCRIPTION
This PR fixes #58.

This PR separates the capture groups from the text. This stops the Markdown files from collapsing the liquid tags in to the text since Markdown without a newline separation is considered all the same paragraph.