### PR TITLE
Update body text color

### DIFF
--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -9,6 +9,11 @@
     line-height: 2.4rem;
     list-style: none;
   }
+
+  a {
+    color: #fff;
+  }
+
   a:hover {
     text-decoration: none;
   }

--- a/_sass/_general.scss
+++ b/_sass/_general.scss
@@ -12,7 +12,7 @@ img {
   max-width: 100%;
 }
 a {
-  color: #5c6364;
+  color: #000000;
 }
 a:hover, a:focus {
   color: #6a4d8a;

--- a/_sass/_latest-news.scss
+++ b/_sass/_latest-news.scss
@@ -61,7 +61,7 @@
 #latest-news .section-content .post .post-entry {
   margin: 40px 0 55px 0;
   padding: 0 30px;
-  color: #8c9597;
+  color: #565e60;
 }
 
 #latest-news .section-content .post .post-button {

--- a/_sass/variables-overrides.scss
+++ b/_sass/variables-overrides.scss
@@ -1,6 +1,6 @@
 $primary: hsl(52, 85%, 55%);
 
-$body-color: #8c9597;
+$body-color: #565e60;
 
 $font-family-sans-serif: "Open Sans", sans-serif;
 $headings-font-family: "Mulish";


### PR DESCRIPTION
This is mainly to address #97. I realize this change is more disruptive than I thought since other elements will look very similar so I tweaked the color values of the other elements without changing the appearance too much.

I've used `#565e60` as the updated body text color as suggested from the original post of the previously linked issue.

However, the updated color now makes the link color in the body text harder to see. So I made it darker to `#000000`.

![image](https://user-images.githubusercontent.com/34962634/216287385-f1235977-c79b-4bbe-8927-972ff0722a0e.png)

However, this also affect the links in the footer so I changed it to `#ffffff` to make it more visible.

![Screenshot from 2023-02-02 17-36-44](https://user-images.githubusercontent.com/34962634/216288028-904179b6-6e56-42c7-8578-1512206fd988.png)