### PR TITLE
Remove AppImage option from the download page

### DIFF
--- a/_platforms/03-linux.md
+++ b/_platforms/03-linux.md
@@ -20,26 +20,6 @@ flatpak remote-add --user --if-not-exists \
 flatpak install --user flathub org.gaphor.Gaphor
 ```
 
-### AppImage
-
-The other option if you are running a recent Linux distribution is to use the
-[AppImage](https://appimage.org/). It is built using Ubuntu 18.04 and most
-likely won't work on older versions.
-
-<a class="btn btn-primary btn-lg" href="https://github.com/gaphor/gaphor/releases/download/{{ site.gaphor_version }}/Gaphor-{{ site.gaphor_version }}-x86_64.AppImage"><i class="fa fa-download"></i> Download AppImage</a>
-
-```bash
-chmod +x Gaphor-{{ site.gaphor_version }}-x86_64.AppImage
-./Gaphor-{{ site.gaphor_version }}-x86_64.AppImage
-```
-
-If you're using Wayland and the AppImage crashes, you can force it to use the
-X11 backend instead.
-
-```bash
-GDK_BACKEND=x11 ./Gaphor-{{ site.gaphor_version }}-x86_64.AppImage
-```
-
 ### Arch Linux
 
 Gaphor can be installed from an [AUR

--- a/po/site.pot
+++ b/po/site.pot
@@ -148,44 +148,6 @@ msgstr ""
 #. type: Title ###
 #: _platforms/03-linux.md
 #, markdown-text, no-wrap
-msgid "AppImage"
-msgstr ""
-
-#. type: Plain text
-#: _platforms/03-linux.md
-#, markdown-text
-msgid "The other option if you are running a recent Linux distribution is to use the [AppImage](https://appimage.org/). It is built using Ubuntu 18.04 and most likely won't work on older versions."
-msgstr ""
-
-#. type: Plain text
-#: _platforms/03-linux.md
-#, markdown-text, no-wrap
-msgid "<a class=\"btn btn-primary btn-lg\" href=\"https://github.com/gaphor/gaphor/releases/download/{{ site.gaphor_version }}/Gaphor-{{ site.gaphor_version }}-x86_64.AppImage\"><i class=\"fa fa-download\"></i> Download AppImage</a>\n"
-msgstr ""
-
-#. type: Fenced code block (bash)
-#: _platforms/03-linux.md
-#, no-wrap
-msgid ""
-"chmod +x Gaphor-{{ site.gaphor_version }}-x86_64.AppImage\n"
-"./Gaphor-{{ site.gaphor_version }}-x86_64.AppImage\n"
-msgstr ""
-
-#. type: Plain text
-#: _platforms/03-linux.md
-#, markdown-text
-msgid "If you're using Wayland and the AppImage crashes, you can force it to use the X11 backend instead."
-msgstr ""
-
-#. type: Fenced code block (bash)
-#: _platforms/03-linux.md
-#, no-wrap
-msgid "GDK_BACKEND=x11 ./Gaphor-{{ site.gaphor_version }}-x86_64.AppImage\n"
-msgstr ""
-
-#. type: Title ###
-#: _platforms/03-linux.md
-#, markdown-text, no-wrap
 msgid "Arch Linux"
 msgstr ""
 


### PR DESCRIPTION
We decided to [stop support for AppImage](https://github.com/gaphor/gaphor/issues/2285).

This PR removes AppImage as a download option.

NB. I'm not sure how to update the `.po` files.