### PR TITLE
Remove twitter, replace Gitter with matrix

### DIFF
--- a/_data/strings.yml
+++ b/_data/strings.yml
@@ -41,8 +41,10 @@ menu:
   contribute: Contribute
 footer:
   love: We love to hear from you
-  open-issue: Open an issue on GitHub
-  tech-docs: Tech docs
+  chat-on: Chat with us
+  code: Contribute code
+  open-issue: Submit an issue
+  tech-docs: Read the docs
   copyright: Copyright &copy; 2020-2023 Arjan Molenaar and Dan Yeaw.
   theme: Theme
 languages:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,21 +8,18 @@
         <div class="row">
             <div class="col-12 col-sm-10 offset-sm-1 col-md-6 col-lg-4">
                 <ul class="fa-ul">
-                    <li><a href="https://gitter.im/gaphor/Lobby"><i class="fa-li fa fa-angle-right"></i>
-                            <i class="fab fa-gitter"></i> Gitter</a></li>
-                    <li><a href="https://twitter.com/modelwithgaphor"><i class="fa-li fa fa-angle-right"></i>
-                            <i class="fab fa-twitter"></i> Twitter</a></li>
+                    <li><a href="https://matrix.to/#/#gaphor_Lobby:gitter.im"><i class="fa-li fa fa-angle-right"></i>
+                        <i class="far fa-comment"></i> {{ site.data.strings.footer.chat-on }}</a></li>
+                    <li><a href="https://github.com/gaphor/gaphor/issues"><i class="fa-li fa fa-angle-right"></i>
+                        <i class="fas fa-bug"></i> {{ site.data.strings.footer.open-issue }}</a></li>
                 </ul>
             </div>
             <div class="col-12 col-sm-10 offset-sm-1 col-md-6 col-lg-4">
                 <ul class="fa-ul">
-                    <li><a href="https://github.com/gaphor"><i class="fa-li fa fa-angle-right"></i>
-                            <i class="fab fa-github"></i> GitHub</a></li>
-                    <li><a href="https://github.com/gaphor/gaphor/issues"><i class="fa-li fa fa-angle-right"></i>
-                            <i class="fas fa-band-aid"></i>{{ site.data.strings.footer.open-issue }}</a>
-                    </li>
                     <li><a href="https://docs.gaphor.org/en/latest"><i class="fa-li fa fa-angle-right"></i>
-                            <i class="fas fa-drafting-compass"></i>{{ site.data.strings.footer.tech-docs }}</a></li>
+                            <i class="fas fa-book"></i> {{ site.data.strings.footer.tech-docs }}</a></li>
+                    <li><a href="https://github.com/gaphor"><i class="fa-li fa fa-angle-right"></i>
+                        <i class="fab fa-github"></i> {{ site.data.strings.footer.code }}</a></li>
                 </ul>
             </div>
         </div>

--- a/_pages/discuss.md
+++ b/_pages/discuss.md
@@ -17,16 +17,12 @@ Contributions are welcome without prejudice from anyone irrespective of age,
 gender, religion, race, or sexuality. If you’re thinking, "but they don't mean
 me", then we especially mean YOU.
 
-## Chat on Gitter
+## Chat on [matrix]
 
-Our real-time conversations are on Gitter and are bridged to Matrix.
-Matrix is the preferred way, since it's more use friendly than bare Gitter.
+Our real-time conversations are on [matrix]. You can join using a chat client
+like Element, Fractal, or one of the other many options.
 
-[<img src="/images/matrix_org.svg" alt="matrix.org" style="height: 1em" /> Join Matrix with Element.io](https://app.element.io/#/room/#gaphor_Lobby:gitter.im)
-
-[<i class="fab fa-gitter"></i> Join Gitter Chat](https://gitter.im/gaphor/lobby)
-
-NB. If you're using a mobile device, use the [Element app](https://element.io/get-started) (for Matrix), the Gitter app is no longer supported.
+[<img src="/images/matrix_org.svg" alt="matrix.org" style="height: 1em" /> Join [matrix]](https://matrix.to/#/#gaphor_Lobby:gitter.im)
 
 ## Submit an Issue on GitHub
 


### PR DESCRIPTION
In the footer:

1. Remove twitter / X
2. Rearrange the buttons
3. Reword them so they all start with a verb
4. Update a couple of the icons

On the discuss page, remove mention of Gitter and link to the matrix.to URL which gives a lot of options on clients to select.